### PR TITLE
chore: enable OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,10 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -31,13 +27,22 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
+      # Use corepack to install pnpm
+      # Update npm to the latest version to enable OIDC
+      - name: Setup Package Managers
+        run: |
+          npm install -g npm@latest
+          npm --version
+          npm install -g corepack@latest --force
+          corepack enable
+
       - name: Install Dependencies
         run: pnpm install
 
       - name: Publish
         uses: JS-DevTools/npm-publish@v3
         with:
-          token: ${{ secrets.RSBUILD_PLUGIN_NPM_TOKEN }}
+          token: empty
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

- https://github.com/orgs/community/discussions/127011
- https://github.com/npm/cli/pull/8336