### PR TITLE
docs: clarify exports source field order

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ For example, in the following example, when the lib package is referenced, the `
 }
 ```
 
-If the sub-project uses [exports](https://nodejs.org/api/packages.html#package-entry-points) field, you also need to add the `source` field in the `exports` field.
+If the sub-project uses the [exports](https://nodejs.org/api/packages.html#package-entry-points) field, you also need to add the `source` field to `exports`.
+
+Note that the declaration order of keys in `exports` affects resolution, so it is recommended to place the `source` field first in each export condition object to ensure the resolver prioritizes the module pointed to by `source`.
 
 ```json title="package.json"
 {
@@ -208,6 +210,8 @@ In `package.json`, the source code file path can be specified using `@custom/sou
   }
 }
 ```
+
+If you use a custom `sourceField` in `exports`, apply the same ordering rule and place that field first in each export condition object, since the key order in `exports` affects resolution priority.
 
 ### resolvePriority
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ In `package.json`, the source code file path can be specified using `@custom/sou
 }
 ```
 
-If you use a custom `sourceField` in `exports`, apply the same ordering rule and place that field first in each export condition object, since the key order in `exports` affects resolution priority.
+If you use a custom `sourceField` in `exports`, place that field first in each export condition object, since the key order in `exports` affects resolution priority.
 
 ### resolvePriority
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ In `package.json`, the source code file path can be specified using `@custom/sou
 }
 ```
 
-If you use a custom `sourceField` in `exports`, place that field first in each export condition object, since the key order in `exports` affects resolution priority.
+If you use a custom field name configured via `sourceField` in `exports` (for example, `@custom/source`), place that field first in each export condition object, since the key order in `exports` affects resolution priority.
 
 ### resolvePriority
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,7 +209,7 @@ pluginSourceBuild({
 }
 ```
 
-如果你在 `exports` 中使用了自定义的 `sourceField`，也需要将该字段放在每个导出条件对象的最前面。因为 `exports` 中键的顺序会影响解析优先级。
+如果你在 `exports` 中使用了通过 `sourceField` 配置的自定义字段名（例如 `@custom/source`），请将该字段放在每个导出条件对象的最前面。因为 `exports` 中键的顺序会影响解析优先级。
 
 ### resolvePriority
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,6 +209,8 @@ pluginSourceBuild({
 }
 ```
 
+如果你在 `exports` 中使用了自定义的 `sourceField`，也需要将该字段放在每个导出条件对象的最前面。因为 `exports` 中键的顺序会影响解析优先级。
+
 ### resolvePriority
 
 - **类型：** `'source' | 'output'`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,6 +104,8 @@ monorepo
 
 如果子项目使用了 [exports](https://nodejs.org/api/packages.html#package-entry-points) 配置，那么你同样需要在 `exports` 中增加 `source` 字段。
 
+需要注意的是，`exports` 中 key 的声明顺序会影响解析结果，因此建议将 `source` 字段放在每个导出条件对象的第一个位置，以确保解析器优先解析 `source` 对应的模块。
+
 ```json title="package.json"
 {
   "name": "lib",


### PR DESCRIPTION
## Summary
- clarify in the READMEs that `exports` key order affects resolution priority
- recommend placing `source` or a custom `sourceField` first in each export condition object so source resolution works as documented
