### PR TITLE
feat: support scoped workspace source builds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Related issue
+
+<!-- For example: Closes #123. Remove this section when there is no related issue. -->
+
+## Testing
+
+- [ ] `pnpm exec rstest run`
+- [ ] `pnpm lint`
+- [ ] `pnpm build`
+
+## Checklist
+
+- [ ] I added or updated tests when behavior changed.
+- [ ] I updated documentation when public APIs or behavior changed.
+- [ ] I kept this pull request focused on one change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+Thanks for contributing to `rsbuild-plugin-source-build`.
+
+## Development setup
+
+1. Fork the repository and clone your fork.
+2. Use Node.js 24 to match the version used in CI.
+3. Enable Corepack and install dependencies:
+
+```bash
+corepack enable
+pnpm install
+```
+
+The pnpm version is declared by the `packageManager` field in `package.json`.
+
+## Development commands
+
+```bash
+# Build the package in watch mode
+pnpm dev
+
+# Create a production build
+pnpm build
+```
+
+## Tests and checks
+
+Add or update tests for behavior changes. Before opening a pull request, run:
+
+```bash
+pnpm exec rstest run
+pnpm lint
+pnpm build
+```
+
+Changes to source-build resolution should include focused unit tests. When a
+change may affect Rsbuild compatibility, also update the miniature monorepo in
+`fixtures/source-build-monorepo` and run the real-version matrix test:
+
+```bash
+pnpm exec rstest run test/source-build-versions.test.ts
+```
+
+The test workflow runs on both Ubuntu and Windows, so avoid platform-specific
+path and symlink assumptions.
+
+## Pull requests
+
+- Create a dedicated branch and keep the pull request focused on one change.
+- Include tests for behavior changes and documentation for public API changes.
+- Link the related issue when one exists.
+- Target the `main` branch.
+- Use a [Conventional Commits](https://www.conventionalcommits.org/) style pull
+  request title, for example `feat: support scoped source resolution` or
+  `fix: preserve package output priority`.
+- Describe what changed, why it changed, and how you verified it.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,32 @@ pluginSourceBuild({
 });
 ```
 
-This is because some packages (such as Mobx) also define a `source` field in their `package.json`. If not distinguished, Rsbuild may mistakenly resolve the source files of those dependencies, leading to unexpected build results or type issues. By using a custom field, you can avoid such conflicts and ensure that Rsbuild behaves predictably when resolving dependencies.
+This makes the source-build contract explicit and avoids conflicts with packages
+that use `source` for another purpose. When using Rspack, the plugin additionally
+limits source resolution to dependent workspace projects discovered by the
+active monorepo analyzer, so unrelated `node_modules` packages are not affected.
+
+## Scoped Source Resolution
+
+With Rspack, the plugin derives the source-build boundary from the monorepo
+project graph. Starting from the current project, it recursively follows package
+dependencies and keeps only workspace projects that declare `sourceField`.
+Requests for those package names can resolve to source; all other package
+requests continue through Rspack's native resolver.
+
+Selected requests are still resolved by Rspack itself. The plugin adds
+`sourceField` to a scoped resolver rather than changing the global resolver, so
+target and dependency conditions, aliases, `resolvePriority`, and native
+output/source fallback behavior are preserved.
+
+As with normal Rspack resolution, a selected package must still be reachable
+through a workspace link, alias, or tsconfig path. The monorepo adapter defines
+the allowed scope; it does not register packages with the resolver.
+
+Custom monorepo integrations can provide that project graph through
+`extraMonorepoStrategies`. TypeScript project references are then augmented
+with the selected projects, but existing `tsconfig.json` references do not add
+packages to the source-build boundary.
 
 ## Configure Project Reference
 
@@ -215,10 +240,15 @@ If you use a custom field name configured via `sourceField` in `exports` (for ex
 
 ### resolvePriority
 
-- **Type:** `'source' | 'output'`
+- **Type:** `'source' | 'output' | Record<string, 'source' | 'output'>`
 - **Default:** `'source'`
 
-Used to control the priority of reading the source code or the output code.
+Used to control the priority of reading the source code or the output code. A
+string applies to every selected workspace package. An object overrides the
+priority by package name; selected packages omitted from the object use
+`'source'`. The object does not select packages—the active monorepo strategy and
+the package dependency graph still determine the source-build boundary.
+Per-package priority maps are supported only when using Rspack.
 
 By default, `@rsbuild/plugin-source-build` will reading the source code first, for example, in the following example, it will read the `source` field.
 
@@ -238,8 +268,71 @@ pluginSourceBuild({
 });
 ```
 
+Different workspace packages can use different priorities:
+
+```ts
+pluginSourceBuild({
+  resolvePriority: {
+    '@example/components': 'source',
+    '@example/utils': 'output',
+  },
+});
+```
+
 - The `exports` field in package.json is not affected by `resolvePriority`.
 - The keys order in `exports` determines the resolving order, earlier declared keys having higher priority.
+
+### projectName
+
+- **Type:** `string`
+- **Default:** The package name at the Rsbuild project root
+
+Specifies the current project in the workspace project graph. Framework
+integrations can pass the package name they already resolved from their own
+application context.
+
+### extraMonorepoStrategies
+
+- **Type:** `Record<string, MonorepoAnalyzer>`
+- **Default:** `undefined`
+
+Adds adapters for monorepo formats other than the built-in pnpm workspace and
+Rush formats. Both `MonorepoAnalyzer` and `Project` are exported from the
+package root:
+
+```ts
+import {
+  type MonorepoAnalyzer,
+  pluginSourceBuild,
+  Project,
+} from '@rsbuild/plugin-source-build';
+
+const customAnalyzer: MonorepoAnalyzer = {
+  check: async (root) => isCustomMonorepo(root),
+  getProjects: async (root) => {
+    const workspacePackages = await readCustomWorkspace(root);
+    return Promise.all(
+      workspacePackages.map(async ({ name, dir }) => {
+        const project = new Project(name, dir);
+        await project.init();
+        return project;
+      }),
+    );
+  },
+};
+
+pluginSourceBuild({
+  projectName: '@example/app',
+  extraMonorepoStrategies: {
+    custom: customAnalyzer,
+  },
+});
+```
+
+The adapter should return all workspace projects. The plugin treats that result
+as the project boundary, recursively follows the current project's package
+dependencies within it, and enables source resolution only for the resulting
+projects that declare `sourceField`.
 
 ## Caveat
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,11 @@ When using `@rsbuild/plugin-source-build`, there are a few things to keep in min
 *.tsbuildinfo
 ```
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for
+development setup, testing, and pull request guidelines.
+
 ## License
 
 [MIT](./LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -333,6 +333,11 @@ Adapter 应返回全部 workspace 项目。插件会把该结果作为项目边�
 *.tsbuildinfo
 ```
 
+## 参与贡献
+
+欢迎参与贡献。开发环境、测试与 Pull Request 约定请参阅
+[CONTRIBUTING.md](./CONTRIBUTING.md)。
+
 ## License
 
 [MIT](./LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,7 +132,26 @@ pluginSourceBuild({
 });
 ```
 
-这是因为某些三方库（例如 Mobx）的 `package.json` 中也包含 `source` 字段，如果不进行区分，Rsbuild 可能会错误地解析这些库的源文件路径，从而导致意料之外的构建结果或类型问题。使用自定义字段可以避免此类冲突，确保 Rsbuild 在解析依赖关系时保持可控的行为。
+这样可以明确源码构建约定，并避免与其他用途的 `source` 字段冲突。使用
+Rspack 时，插件还会把源码解析限定在当前 monorepo analyzer 找到的 workspace
+依赖项目内，不会影响无关的 `node_modules` 包。
+
+## 限定源码解析范围
+
+使用 Rspack 时，插件会从 monorepo 项目图中确定源码构建范围：从当前项目出发，
+递归读取 package 依赖关系，并只保留声明了 `sourceField` 的 workspace 项目。
+只有这些包名对应的请求可以解析到源码，其他包请求继续使用 Rspack 原生解析。
+
+选中的请求仍由 Rspack 原生 resolver 解析。插件只在限定 resolver 中补充
+`sourceField`，不会修改全局 resolver，因此可以保留 target、依赖类型、alias、
+`resolvePriority` 以及 output/source fallback 等原生语义。
+
+与普通 Rspack 解析一致，选中的包仍需通过 workspace link、alias 或 tsconfig path
+可达。monorepo Adapter 只负责限定允许生效的范围，不负责向 resolver 注册包。
+
+自定义 monorepo 集成可以通过 `extraMonorepoStrategies` 提供项目图。插件会把选中的
+项目补充到 TypeScript project references；但 `tsconfig.json` 中原有的 references
+不会反向扩大源码构建的包范围。
 
 ## 配置 Project Reference
 
@@ -213,10 +232,13 @@ pluginSourceBuild({
 
 ### resolvePriority
 
-- **类型：** `'source' | 'output'`
+- **类型：** `'source' | 'output' | Record<string, 'source' | 'output'>`
 - **默认值：** `'source'`
 
-用于控制优先读取源代码还是产物代码。
+用于控制优先读取源代码还是产物代码。传入字符串时会作用于所有选中的 workspace
+包；传入对象时会按包名覆盖优先级，对象中未配置的已选中包使用 `'source'`。
+这个对象不负责选择包，源码构建范围仍由当前 monorepo Strategy 和 package 依赖图决定。
+包级优先级对象仅支持在 Rspack 中使用。
 
 默认情况下，`@rsbuild/plugin-source-build`会优先读取源代码，比如在下面的例子中，它会读取 `source` 字段。
 
@@ -236,8 +258,67 @@ pluginSourceBuild({
 });
 ```
 
+不同 workspace 包可以配置不同的解析优先级：
+
+```ts
+pluginSourceBuild({
+  resolvePriority: {
+    '@example/components': 'source',
+    '@example/utils': 'output',
+  },
+});
+```
+
 - package.json 中的 `exports` 字段不受 `resolvePriority` 的影响。
 - `exports` 中 key 的声明顺序决定了读取顺序，较早声明的 key 具有更高的优先级。
+
+### projectName
+
+- **类型：** `string`
+- **默认值：** Rsbuild 项目根目录对应的包名
+
+用于指定 workspace 项目图中的当前项目。框架集成可以直接传入其应用上下文中已经
+确定的包名。
+
+### extraMonorepoStrategies
+
+- **类型：** `Record<string, MonorepoAnalyzer>`
+- **默认值：** `undefined`
+
+用于为 pnpm workspace 和 Rush 以外的 monorepo 格式增加 Adapter。
+`MonorepoAnalyzer` 和 `Project` 均可从包根入口导入：
+
+```ts
+import {
+  type MonorepoAnalyzer,
+  pluginSourceBuild,
+  Project,
+} from '@rsbuild/plugin-source-build';
+
+const customAnalyzer: MonorepoAnalyzer = {
+  check: async (root) => isCustomMonorepo(root),
+  getProjects: async (root) => {
+    const workspacePackages = await readCustomWorkspace(root);
+    return Promise.all(
+      workspacePackages.map(async ({ name, dir }) => {
+        const project = new Project(name, dir);
+        await project.init();
+        return project;
+      }),
+    );
+  },
+};
+
+pluginSourceBuild({
+  projectName: '@example/app',
+  extraMonorepoStrategies: {
+    custom: customAnalyzer,
+  },
+});
+```
+
+Adapter 应返回全部 workspace 项目。插件会把该结果作为项目边界，只在其中递归读取
+当前项目的 package 依赖关系，并仅对最终选中且声明了 `sourceField` 的项目启用源码解析。
 
 ## 注意事项
 

--- a/fixtures/source-build-monorepo/README.md
+++ b/fixtures/source-build-monorepo/README.md
@@ -1,0 +1,13 @@
+# Source-build monorepo fixture
+
+This fixture is copied to a temporary directory by the Rsbuild version-matrix
+integration test. The test creates workspace links at runtime so the repository
+does not contain generated `node_modules` entries.
+
+It covers these source-build boundaries:
+
+- `source-first`: a direct workspace dependency built from TypeScript source.
+- `transitive`: a transitive workspace dependency built from source.
+- `output-first`: a selected dependency using a package-level output priority.
+- `undeclared`: a linked workspace package outside the app dependency graph.
+- `vendor/external`: a non-workspace package that also declares `source`.

--- a/fixtures/source-build-monorepo/app/package.json
+++ b/fixtures/source-build-monorepo/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/app",
+  "private": true,
+  "dependencies": {
+    "@fixture/external": "1.0.0",
+    "@fixture/output-first": "workspace:*",
+    "@fixture/source-first": "workspace:*"
+  }
+}

--- a/fixtures/source-build-monorepo/app/src/index.ts
+++ b/fixtures/source-build-monorepo/app/src/index.ts
@@ -1,0 +1,6 @@
+import external from '@fixture/external';
+import outputFirst from '@fixture/output-first';
+import sourceFirst from '@fixture/source-first';
+import undeclared from '@fixture/undeclared';
+
+export default [sourceFirst, outputFirst, undeclared, external];

--- a/fixtures/source-build-monorepo/app/tsconfig.json
+++ b/fixtures/source-build-monorepo/app/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "compilerOptions": {}
+}

--- a/fixtures/source-build-monorepo/package.json
+++ b/fixtures/source-build-monorepo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "source-build-monorepo-fixture",
+  "private": true
+}

--- a/fixtures/source-build-monorepo/packages/output-first/lib/index.js
+++ b/fixtures/source-build-monorepo/packages/output-first/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = 'output-first-dist';

--- a/fixtures/source-build-monorepo/packages/output-first/package.json
+++ b/fixtures/source-build-monorepo/packages/output-first/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/output-first",
+  "version": "1.0.0",
+  "source": "./src/index.ts",
+  "main": "./lib/index.js"
+}

--- a/fixtures/source-build-monorepo/packages/output-first/src/index.ts
+++ b/fixtures/source-build-monorepo/packages/output-first/src/index.ts
@@ -1,0 +1,1 @@
+export default 'output-first-source';

--- a/fixtures/source-build-monorepo/packages/source-first/lib/index.js
+++ b/fixtures/source-build-monorepo/packages/source-first/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = 'source-first-dist';

--- a/fixtures/source-build-monorepo/packages/source-first/package.json
+++ b/fixtures/source-build-monorepo/packages/source-first/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/source-first",
+  "version": "1.0.0",
+  "source": "./src/index.ts",
+  "main": "./lib/index.js",
+  "dependencies": {
+    "@fixture/transitive": "workspace:*"
+  }
+}

--- a/fixtures/source-build-monorepo/packages/source-first/src/index.ts
+++ b/fixtures/source-build-monorepo/packages/source-first/src/index.ts
@@ -1,0 +1,5 @@
+import transitive from '@fixture/transitive';
+
+const prefix: string = 'source-first';
+
+export default `${prefix}:${transitive}`;

--- a/fixtures/source-build-monorepo/packages/transitive/lib/index.js
+++ b/fixtures/source-build-monorepo/packages/transitive/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = 'transitive-dist';

--- a/fixtures/source-build-monorepo/packages/transitive/package.json
+++ b/fixtures/source-build-monorepo/packages/transitive/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/transitive",
+  "version": "1.0.0",
+  "source": "./src/index.ts",
+  "main": "./lib/index.js"
+}

--- a/fixtures/source-build-monorepo/packages/transitive/src/index.ts
+++ b/fixtures/source-build-monorepo/packages/transitive/src/index.ts
@@ -1,0 +1,3 @@
+const value: string = 'transitive-source';
+
+export default value;

--- a/fixtures/source-build-monorepo/packages/undeclared/lib/index.js
+++ b/fixtures/source-build-monorepo/packages/undeclared/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = 'undeclared-dist';

--- a/fixtures/source-build-monorepo/packages/undeclared/package.json
+++ b/fixtures/source-build-monorepo/packages/undeclared/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/undeclared",
+  "version": "1.0.0",
+  "source": "./src/index.ts",
+  "main": "./lib/index.js"
+}

--- a/fixtures/source-build-monorepo/packages/undeclared/src/index.ts
+++ b/fixtures/source-build-monorepo/packages/undeclared/src/index.ts
@@ -1,0 +1,1 @@
+export default 'undeclared-source';

--- a/fixtures/source-build-monorepo/pnpm-workspace.yaml
+++ b/fixtures/source-build-monorepo/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - app
+  - packages/*

--- a/fixtures/source-build-monorepo/vendor/external/lib/index.js
+++ b/fixtures/source-build-monorepo/vendor/external/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = 'external-dist';

--- a/fixtures/source-build-monorepo/vendor/external/package.json
+++ b/fixtures/source-build-monorepo/vendor/external/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/external",
+  "version": "1.0.0",
+  "source": "./src/index.js",
+  "main": "./lib/index.js"
+}

--- a/fixtures/source-build-monorepo/vendor/external/src/index.js
+++ b/fixtures/source-build-monorepo/vendor/external/src/index.js
@@ -1,0 +1,1 @@
+module.exports = 'external-source';

--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.1.13",
+    "@rsbuild/core-1.0": "npm:@rsbuild/core@1.0.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-type-check": "^1.6.0",
     "@rslib/core": "^0.23.2",
     "@rslint/core": "^0.8.1",
+    "@rspack/core": "^2.1.3",
     "@rstest/core": "^0.11.8",
     "@rstest/playwright": "^0.11.8",
     "@types/node": "^24.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,25 +20,31 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.13
-        version: 2.1.13
+        version: 2.1.13(core-js@3.38.1)
+      '@rsbuild/core-1.0':
+        specifier: npm:@rsbuild/core@1.0.1
+        version: '@rsbuild/core@1.0.1'
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.13(core-js@3.38.1))(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       '@rsbuild/plugin-type-check':
         specifier: ^1.6.0
-        version: 1.6.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 1.6.0(@rsbuild/core@2.1.13(core-js@3.38.1))(@rspack/core@2.1.10(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@rslib/core':
         specifier: ^0.23.2
-        version: 0.23.2(typescript@6.0.3)
+        version: 0.23.2(core-js@3.38.1)(typescript@6.0.3)
       '@rslint/core':
         specifier: ^0.8.1
         version: 0.8.1
+      '@rspack/core':
+        specifier: ^2.1.3
+        version: 2.1.10(@swc/helpers@0.5.23)
       '@rstest/core':
         specifier: ^0.11.8
-        version: 0.11.8
+        version: 0.11.8(core-js@3.38.1)
       '@rstest/playwright':
         specifier: ^0.11.8
-        version: 0.11.8(@rstest/core@0.11.8)(playwright@1.62.1)
+        version: 0.11.8(@rstest/core@0.11.8(core-js@3.38.1))(playwright@1.62.1)
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -284,6 +290,18 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@module-federation/runtime-tools@0.5.1':
+    resolution: {integrity: sha512-nfBedkoZ3/SWyO0hnmaxuz0R0iGPSikHZOAZ0N/dVSQaIzlffUo35B5nlC2wgWIc0JdMZfkwkjZRrnuuDIJbzg==}
+
+  '@module-federation/runtime@0.5.1':
+    resolution: {integrity: sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==}
+
+  '@module-federation/sdk@0.5.1':
+    resolution: {integrity: sha512-exvchtjNURJJkpqjQ3/opdbfeT2wPKvrbnGnyRkrwW5o3FH1LaST1tkiNviT6OXTexGaVc2DahbdniQHVtQ7pA==}
+
+  '@module-federation/webpack-bundler-runtime@0.5.1':
+    resolution: {integrity: sha512-mMhRFH0k2VjwHt3Jol9JkUsmI/4XlrAoBG3E0o7HoyoPYv1UFOWyqAflfANcUPgbYpvqmyLzDcO+3IT36LXnrA==}
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -301,6 +319,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@rsbuild/core@1.0.1':
+    resolution: {integrity: sha512-LbvlUxJut/bRgfu3gUsIzlQmJdZbEtEIPBygCwtCSgrjWeGO0zOqkMyO71jFqTyY8A32ygAz2P8NdUqiQbmFbQ==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
 
   '@rsbuild/core@2.1.13':
     resolution: {integrity: sha512-Z+6MzmjOio4+bFZQ24k+7ge/oNCOdXIunAssrswTNE8AIf6mcyXpJZevRXRiOEMZasRPA8VNyh+9JngQLg729Q==}
@@ -397,9 +420,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-darwin-arm64@1.0.14':
+    resolution: {integrity: sha512-dHvlF6T6ctThGDIdvkSdacroA1xlCxfteuppBj8BX/UxzLPr4xsaEtNilfJmFfd2/J02UQyTQauN/9EBuA+YkA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-arm64@2.1.10':
     resolution: {integrity: sha512-DZlcTpbIb2mjeS1aSG4k01UH33Zj7T+k8ZylPK6HmsKs4JvK4wgpWFC78WVv3p/Aj3MZS6DwtDLwpZ2Ihj/fpg==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.0.14':
+    resolution: {integrity: sha512-q4Da1Bn/4xTLhhnOkT+fjP2STsSCfp4z03/J/h8tCVG/UYz56Ud3q1UEOK33c5Fxw1C4GlhEh5yYOlSAdxFQLQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@2.1.10':
@@ -407,11 +440,23 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-linux-arm64-gnu@1.0.14':
+    resolution: {integrity: sha512-JogYtL3VQS9wJ3p3FNhDqinm7avrMsdwz4erP7YCjD7idob93GYAE7dPrHUzSNVnCBYXRaHJYZHDQs7lKVcYZw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-arm64-gnu@2.1.10':
     resolution: {integrity: sha512-laevn9g+E5PAUEGqiKe6Ju5KApsuQYp+bPI17XS3Lkl8eqL5pS/BmHYU7QMlst4GzV8+wlruVTMh//+st6Vqzg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@1.0.14':
+    resolution: {integrity: sha512-qgybhxI/nnoa8CUz7zKTC0Oh37NZt9uRxsSV7+ZYrfxqbrVCoNVuutPpY724uUHy1M6W34kVEm1uT1N4Ka5cZg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@2.1.10':
     resolution: {integrity: sha512-V71+Qz5G72+ROZXrJn5zxOszdG1AEbO8pcC/itXXtf4yRR6a3bVHKNKGhipBNxb8eI6cnD/01FH1h3ZG655jLw==}
@@ -443,11 +488,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-x64-gnu@1.0.14':
+    resolution: {integrity: sha512-5vzaDRw3/sGKo3ax/1cU3/cxqNjajwlt2LU288vXNe1/n8oe/pcDfYcTugpOe/A1DqzadanudJszLpFcKsaFtQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-x64-gnu@2.1.10':
     resolution: {integrity: sha512-Fat09V6jUuyo9qG7Wyj9cQ31VDfLmokXyBtGqKxY5OvSWHereB7QUub5btbPXHwbp6Iq4aAQyUbbLTzvR1YaBw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@1.0.14':
+    resolution: {integrity: sha512-4U6QD9xVS1eGme52DuJr6Fg/KdcUfJ+iKwH49Up460dZ/fLvGylnVGA+V0mzPlKi8gfy7NwFuYXZdu3Pwi1YYg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-musl@2.1.10':
     resolution: {integrity: sha512-lhHOnIJ4ClpIlA1f1L8aoxEZivYLjnjq5A6jKKz7BKsm+cHK8kqqEm6lO5KqA5xQT0Lonq1o28bmKHEj6JHInw==}
@@ -459,9 +516,19 @@ packages:
     resolution: {integrity: sha512-KY5YbWbuvYcoaLXnV+vzZOvGRCeb6jt4EpVpKdph1h1IJjwX/ju15EQ+GOe3iecZEdf0OttQcNVcwBkLkFT9ag==}
     cpu: [wasm32]
 
+  '@rspack/binding-win32-arm64-msvc@1.0.14':
+    resolution: {integrity: sha512-SjeYw7qqRHYZ5RPClu+ffKZsShQdU3amA1OwC3M0AS6dbfEcji8482St3Y8Z+QSzYRapCEZij9LMM/9ypEhISg==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rspack/binding-win32-arm64-msvc@2.1.10':
     resolution: {integrity: sha512-z4GWzMLofaDGpAt9Z+MlN88LlUBDm+zM6R2GdOOPM6/4g/h3/+47OP7casmSL3AwTGYBEJqogwt08sRSosB6Cg==}
     cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.0.14':
+    resolution: {integrity: sha512-m1gUiVyz3Z3VYIK/Ayo5CVHBjnEeRk9a+KIpKSsq1yhZItnMgjtr4bKabU9vjxalO4UoaSmVzODJI8lJBlnn5Q==}
+    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@2.1.10':
@@ -469,13 +536,30 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.0.14':
+    resolution: {integrity: sha512-Gbeg+bayMF9VP9xmlxySL/TC2XrS6/LZM/pqcNOTLHx6LMG/VXCcmKB0rOZo8MzLXEt8D/lQmQ/B6g7pSaAw0g==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.1.10':
     resolution: {integrity: sha512-pgp23pLrzfhGnKycxzr7ifP17lAbWZEfnx1bX8gXtYrnpJ66DRNyTKSzxB6sa/HBWjS1L8PX5TjMZ44WfPydqQ==}
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding@1.0.14':
+    resolution: {integrity: sha512-0wWqFvr9hkF4LgNPgWfkTU0hhkZAMvOytoCs2p+wDX1Up1E/SgJ1U1JAsCxsl1XtUKm7mRvdWHzJmHbza3y89Q==}
+
   '@rspack/binding@2.1.10':
     resolution: {integrity: sha512-vnu/UP5HnrND15lO9+VeG6eUrbTyycHNQNQ3XEiRiFojuoiGZkIZC3Hbzr8qQH44C6vScPODEPvvIVvLcO2LpQ==}
+
+  '@rspack/core@1.0.14':
+    resolution: {integrity: sha512-xHl23lxJZNjItGc5YuE9alz3yjb56y7EgJmAcBMPHMqgjtUt8rBu4xd/cSUjbr9/lLF9N4hdyoJiPJOFs9LEjw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
 
   '@rspack/core@2.1.10':
     resolution: {integrity: sha512-YSS2/Xxz8uiG/KXDkqOoA3dTetNo/vysk7bAexQOrU8iuq7JuzDTTAwLKvWZnwmvME8M8m5wcM4YvfIwYmidHA==}
@@ -488,6 +572,10 @@ packages:
         optional: true
       '@swc/helpers':
         optional: true
+
+  '@rspack/lite-tapable@1.0.1':
+    resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
+    engines: {node: '>=16.0.0'}
 
   '@rspack/lite-tapable@1.1.2':
     resolution: {integrity: sha512-1OnyWChLGE46YzWyjlmYJssOu/Y0STAnnr2ueKPqDCYTf63GJMs0mxNnCul4dNiVqHYPKv3/fxrTY3IpqoVwZQ==}
@@ -560,9 +648,15 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  core-js@3.38.1:
+    resolution: {integrity: sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -950,6 +1044,22 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@module-federation/runtime-tools@0.5.1':
+    dependencies:
+      '@module-federation/runtime': 0.5.1
+      '@module-federation/webpack-bundler-runtime': 0.5.1
+
+  '@module-federation/runtime@0.5.1':
+    dependencies:
+      '@module-federation/sdk': 0.5.1
+
+  '@module-federation/sdk@0.5.1': {}
+
+  '@module-federation/webpack-bundler-runtime@0.5.1':
+    dependencies:
+      '@module-federation/runtime': 0.5.1
+      '@module-federation/sdk': 0.5.1
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
       '@emnapi/core': 1.11.3
@@ -969,38 +1079,50 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@rsbuild/core@2.1.13':
+  '@rsbuild/core@1.0.1':
+    dependencies:
+      '@rspack/core': 1.0.14(@swc/helpers@0.5.23)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.23
+      caniuse-lite: 1.0.30001809
+      core-js: 3.38.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  '@rsbuild/core@2.1.13(core-js@3.38.1)':
     dependencies:
       '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.38.1
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13(core-js@3.38.1))(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.13
+      '@rsbuild/core': 2.1.13(core-js@3.38.1)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.1.13(core-js@3.38.1))(@rspack/core@2.1.10(@swc/helpers@0.5.23))(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.6.1(@rspack/core@2.1.10(@swc/helpers@0.5.23))(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.13
+      '@rsbuild/core': 2.1.13(core-js@3.38.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rslib/core@0.23.2(typescript@6.0.3)':
+  '@rslib/core@0.23.2(core-js@3.38.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.13
-      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.13)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.13(core-js@3.38.1)
+      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.13(core-js@3.38.1))(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -1045,13 +1167,25 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.8.1':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.0.14':
+    optional: true
+
   '@rspack/binding-darwin-arm64@2.1.10':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.0.14':
     optional: true
 
   '@rspack/binding-darwin-x64@2.1.10':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.0.14':
+    optional: true
+
   '@rspack/binding-linux-arm64-gnu@2.1.10':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.0.14':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.1.10':
@@ -1069,7 +1203,13 @@ snapshots:
   '@rspack/binding-linux-s390x-gnu@2.1.10':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.0.14':
+    optional: true
+
   '@rspack/binding-linux-x64-gnu@2.1.10':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.0.14':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.1.10':
@@ -1082,14 +1222,35 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
+  '@rspack/binding-win32-arm64-msvc@1.0.14':
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.1.10':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@1.0.14':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.10':
     optional: true
 
+  '@rspack/binding-win32-x64-msvc@1.0.14':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.1.10':
     optional: true
+
+  '@rspack/binding@1.0.14':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.0.14
+      '@rspack/binding-darwin-x64': 1.0.14
+      '@rspack/binding-linux-arm64-gnu': 1.0.14
+      '@rspack/binding-linux-arm64-musl': 1.0.14
+      '@rspack/binding-linux-x64-gnu': 1.0.14
+      '@rspack/binding-linux-x64-musl': 1.0.14
+      '@rspack/binding-win32-arm64-msvc': 1.0.14
+      '@rspack/binding-win32-ia32-msvc': 1.0.14
+      '@rspack/binding-win32-x64-msvc': 1.0.14
 
   '@rspack/binding@2.1.10':
     optionalDependencies:
@@ -1108,11 +1269,22 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.10
       '@rspack/binding-win32-x64-msvc': 2.1.10
 
+  '@rspack/core@1.0.14(@swc/helpers@0.5.23)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.5.1
+      '@rspack/binding': 1.0.14
+      '@rspack/lite-tapable': 1.0.1
+      caniuse-lite: 1.0.30001809
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
   '@rspack/core@2.1.10(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.10
     optionalDependencies:
       '@swc/helpers': 0.5.23
+
+  '@rspack/lite-tapable@1.0.1': {}
 
   '@rspack/lite-tapable@1.1.2': {}
 
@@ -1122,17 +1294,17 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
 
-  '@rstest/core@0.11.8':
+  '@rstest/core@0.11.8(core-js@3.38.1)':
     dependencies:
-      '@rsbuild/core': 2.1.13
+      '@rsbuild/core': 2.1.13(core-js@3.38.1)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstest/playwright@0.11.8(@rstest/core@0.11.8)(playwright@1.62.1)':
+  '@rstest/playwright@0.11.8(@rstest/core@0.11.8(core-js@3.38.1))(playwright@1.62.1)':
     dependencies:
-      '@rstest/core': 0.11.8
+      '@rstest/core': 0.11.8(core-js@3.38.1)
       playwright: 1.62.1
 
   '@swc/helpers@0.5.23':
@@ -1176,6 +1348,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  caniuse-lite@1.0.30001809: {}
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -1187,6 +1361,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  core-js@3.38.1: {}
 
   csstype@3.2.3: {}
 
@@ -1299,10 +1475,10 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.13)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.13(core-js@3.38.1))(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.13
+      '@rsbuild/core': 2.1.13(core-js@3.38.1)
     optionalDependencies:
       typescript: 6.0.3
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,6 @@ export {
 } from './plugin.js';
 export { Project } from './project.js';
 export { getMonorepoBaseData, getMonorepoSubProjects } from './common/index.js';
+export type { ExtraMonorepoStrategies } from './project-utils/index.js';
+export type { ResolvePriority } from './source-build/resolve.js';
 export type { MonorepoAnalyzer } from './types/index.js';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,38 +8,64 @@ import {
   getDependentProjects,
 } from './project-utils/index.js';
 import type { Project } from './project.js';
+import {
+  createSourceBuildPackages,
+  type ResolvePriority,
+} from './source-build/resolve.js';
+import { SourceBuildResolverPlugin } from './source-build/rspack-plugin.js';
 import type { TsConfig } from './types/index.js';
 
 export const PLUGIN_SOURCE_BUILD_NAME = 'rsbuild:source-build';
 
-export const getSourceInclude = async (options: {
-  projects: Project[];
-  sourceField: string;
-}): Promise<string[]> => {
-  const { projects, sourceField } = options;
+const PACKAGE_RESOLVE_PRIORITIES = new Set(['source', 'output']);
 
-  const includes = [];
-  for (const project of projects) {
-    includes.push(
-      ...project.getSourceEntryPaths({ field: sourceField, exports: true }),
+function validateResolvePriority(resolvePriority: unknown): void {
+  let entries: [string, unknown][];
+  if (typeof resolvePriority === 'string') {
+    entries = [['resolvePriority', resolvePriority]];
+  } else if (
+    resolvePriority &&
+    typeof resolvePriority === 'object' &&
+    !Array.isArray(resolvePriority)
+  ) {
+    entries = Object.entries(resolvePriority);
+  } else {
+    throw new Error(
+      `[${PLUGIN_SOURCE_BUILD_NAME}] resolvePriority must be "source", "output", or a package-name map.`,
     );
   }
 
-  return includes;
-};
+  for (const [packageName, priority] of entries) {
+    if (!PACKAGE_RESOLVE_PRIORITIES.has(priority as string)) {
+      throw new Error(
+        `[${PLUGIN_SOURCE_BUILD_NAME}] Invalid resolvePriority for "${packageName}": expected "source" or "output", received ${JSON.stringify(priority)}.`,
+      );
+    }
+  }
+}
 
 export interface PluginSourceBuildOptions {
   /**
    * Used to configure the resolve field of the source code files.
-   * @default 'source''
+   * @default 'source'
    */
   sourceField?: string;
   /**
-   * Whether to read source code or output code first.
+   * Whether to read source code or output code first. Use a package-name map
+   * to override the priority for individual selected workspace packages.
    * @default 'source'
    */
-  resolvePriority?: 'source' | 'output';
+  resolvePriority?: ResolvePriority;
+  /**
+   * The package name of the project that consumes workspace dependencies.
+   * Defaults to the package found at the Rsbuild project root.
+   */
   projectName?: string;
+  /**
+   * Additional adapters for discovering projects in custom monorepo formats.
+   * The plugin uses the adapter result as the workspace project boundary, then
+   * recursively selects dependencies of the current project from that result.
+   */
   extraMonorepoStrategies?: ExtraMonorepoStrategies;
 }
 
@@ -52,6 +78,7 @@ export function pluginSourceBuild(
     resolvePriority = 'source',
     extraMonorepoStrategies,
   } = options ?? {};
+  validateResolvePriority(resolvePriority);
 
   return {
     name: PLUGIN_SOURCE_BUILD_NAME,
@@ -59,28 +86,34 @@ export function pluginSourceBuild(
     setup(api) {
       const projectRootPath = api.context.rootPath;
 
-      let projects: Project[] | undefined;
-
-      api.modifyEnvironmentConfig(async (config) => {
-        projects =
-          projects ||
-          (await getDependentProjects(projectName || projectRootPath, {
+      let projectsPromise: Promise<Project[]> | undefined;
+      const getProjects = () => {
+        projectsPromise ||= getDependentProjects(
+          projectName || projectRootPath,
+          {
             cwd: projectRootPath,
             recursive: true,
             filter: filterByField(sourceField, true),
             extraMonorepoStrategies,
-          }));
-
-        const includes = await getSourceInclude({
-          projects,
-          sourceField,
-        });
-
-        config.source = config.source ?? {};
-        config.source.include = [...(config.source.include ?? []), ...includes];
-      });
+          },
+        );
+        return projectsPromise;
+      };
 
       api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+        // Rspack uses SourceBuildResolverPlugin below so the source condition is
+        // applied only to dependent workspace projects discovered by the
+        // monorepo analyzer. Keep the legacy rule configuration for other
+        // bundlers.
+        if (api.context.bundlerType === 'rspack') {
+          return;
+        }
+        if (typeof resolvePriority !== 'string') {
+          throw new Error(
+            `[${PLUGIN_SOURCE_BUILD_NAME}] Per-package resolvePriority is only supported with Rspack.`,
+          );
+        }
+
         // TODO: remove `ts` when Rsbuild v1 is no longer supported.
         for (const ruleId of ['ts', CHAIN_ID.RULE.JS]) {
           if (chain.module.rules.get(ruleId)) {
@@ -107,7 +140,7 @@ export function pluginSourceBuild(
       ): Promise<string[]> => {
         const references = new Set<string>();
 
-        for (const project of projects || []) {
+        for (const project of await getProjects()) {
           const filePath = path.join(project.dir, 'tsconfig.json');
           if (fs.existsSync(filePath)) {
             references.add(filePath);
@@ -149,6 +182,16 @@ export function pluginSourceBuild(
 
       if (api.context.bundlerType === 'rspack') {
         api.modifyRspackConfig(async (config, { environment }) => {
+          const projects = await getProjects();
+          const packages = createSourceBuildPackages(projects, {
+            resolvePriority,
+          });
+
+          config.plugins ||= [];
+          config.plugins.push(
+            new SourceBuildResolverPlugin(packages, sourceField),
+          );
+
           const { tsconfigPath } = environment;
           if (!tsconfigPath) {
             return;

--- a/src/project-utils/filter.ts
+++ b/src/project-utils/filter.ts
@@ -1,22 +1,32 @@
 import type { Project } from '../project.js';
-import type { ExportsConfig } from '../types/packageJson.js';
+
+type ExportsTarget =
+  string | null | ExportsTarget[] | { [condition: string]: ExportsTarget };
 
 export type Filter = FilterFunction;
 export type FilterFunction = (
   projects: Project[],
 ) => Project[] | Promise<Project[]>;
 
-function hasExportsSourceField(
-  exportsConfig: ExportsConfig,
-  sourceField: string,
-) {
-  return (
-    typeof exportsConfig[sourceField] === 'string' ||
-    Object.values(exportsConfig).some(
-      (moduleRules) =>
-        typeof moduleRules === 'object' &&
-        typeof moduleRules[sourceField] === 'string',
-    )
+function hasExportFieldTarget(
+  target: ExportsTarget,
+  fieldName: string,
+  fieldMatched = false,
+): boolean {
+  if (typeof target === 'string') {
+    return fieldMatched;
+  }
+  if (Array.isArray(target)) {
+    return target.some((item) =>
+      hasExportFieldTarget(item, fieldName, fieldMatched),
+    );
+  }
+  if (!target) {
+    return false;
+  }
+
+  return Object.entries(target).some(([key, value]) =>
+    hasExportFieldTarget(value, fieldName, fieldMatched || key === fieldName),
   );
 }
 
@@ -27,7 +37,7 @@ export const filterByField =
       return (
         fieldName in p.metaData ||
         (checkExports &&
-          hasExportsSourceField(p.metaData.exports || {}, fieldName))
+          hasExportFieldTarget(p.metaData.exports || {}, fieldName))
       );
     });
   };

--- a/src/source-build/dependency-resolver-tracker.ts
+++ b/src/source-build/dependency-resolver-tracker.ts
@@ -1,0 +1,92 @@
+import { getPackageRequestName } from './resolve.js';
+
+export interface TrackedDependencyResolveData {
+  context?: string;
+  contextInfo?: {
+    issuer?: string;
+  };
+  request?: string;
+}
+
+interface TrackedDependencyResolver<T> {
+  data: T;
+  resume: () => void;
+}
+
+interface DependencyResolverQueue<T> {
+  active: TrackedDependencyResolver<T>;
+  pending: Array<TrackedDependencyResolver<T>>;
+}
+
+/**
+ * Correlates dependency-specific resolvers with factorization requests.
+ *
+ * @remarks
+ * Rspack can factorize identical requests concurrently, so callback order is
+ * not a stable correlation key. Identical context, issuer, and request tuples
+ * are serialized until the matching factorize tap consumes their resolver.
+ *
+ * @internal
+ */
+export class DependencyResolverTracker<
+  T extends TrackedDependencyResolveData = TrackedDependencyResolveData,
+> {
+  private readonly queues = new Map<string, DependencyResolverQueue<T>>();
+
+  add(data: T, resume: () => void): void {
+    const { context, request } = data;
+    if (!context || !request || !getPackageRequestName(request)) {
+      resume();
+      return;
+    }
+
+    const key = this.getKey(context, request, data.contextInfo?.issuer);
+    const queue = this.queues.get(key);
+    const trackedResolver = { data, resume };
+    if (queue) {
+      queue.pending.push(trackedResolver);
+      return;
+    }
+
+    this.queues.set(key, {
+      active: trackedResolver,
+      pending: [],
+    });
+    resume();
+  }
+
+  get(context: string, request: string, issuer?: string): T | undefined {
+    const key = this.getKey(context, request, issuer);
+    return this.queues.get(key)?.active.data;
+  }
+
+  release(context: string, request: string, issuer?: string): void {
+    const key = this.getKey(context, request, issuer);
+    const queue = this.queues.get(key);
+    if (!queue) {
+      return;
+    }
+
+    const next = queue.pending.shift();
+    if (!next) {
+      this.queues.delete(key);
+      return;
+    }
+
+    queue.active = next;
+    next.resume();
+  }
+
+  clear(): void {
+    for (const queue of this.queues.values()) {
+      for (const resolver of queue.pending) {
+        resolver.resume();
+      }
+    }
+    this.queues.clear();
+  }
+
+  private getKey(context: string, request: string, issuer = ''): string {
+    return `${context}\0${issuer}\0${request}`;
+  }
+}

--- a/src/source-build/resolve.ts
+++ b/src/source-build/resolve.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import type { Project } from '../project.js';
+
+const SCOPED_PACKAGE_SEGMENTS = 2;
+
+export type PackageResolvePriority = 'source' | 'output';
+
+export type ResolvePriority =
+  PackageResolvePriority | Record<string, PackageResolvePriority>;
+
+export interface SourceBuildPackage {
+  resolvePriority: PackageResolvePriority;
+  root: string;
+}
+
+export type SourceBuildPackages = Map<string, SourceBuildPackage>;
+
+export const PLUGIN_SOURCE_BUILD_RESOLVER_NAME =
+  'rsbuild:source-build-resolver';
+
+export function getPackageRequestName(request: string): string | undefined {
+  if (request.startsWith('.') || path.isAbsolute(request)) {
+    return;
+  }
+
+  const resource = request.split(/[?#]/, 1)[0];
+  const segments = resource.split('/');
+  const packageName = resource.startsWith('@')
+    ? segments.slice(0, SCOPED_PACKAGE_SEGMENTS).join('/')
+    : segments[0];
+
+  if (
+    !packageName ||
+    (resource.startsWith('@') && segments.length < SCOPED_PACKAGE_SEGMENTS)
+  ) {
+    return;
+  }
+  return packageName;
+}
+
+export function getSourceBuildPackage(
+  request: string,
+  packages: SourceBuildPackages,
+): SourceBuildPackage | undefined {
+  const packageName = getPackageRequestName(request);
+  return packageName ? packages.get(packageName) : undefined;
+}
+
+export function createSourceBuildPackages(
+  projects: Project[],
+  options: {
+    resolvePriority: ResolvePriority;
+  },
+): SourceBuildPackages {
+  return new Map(
+    projects.map((project) => [
+      project.name,
+      {
+        resolvePriority:
+          typeof options.resolvePriority === 'string'
+            ? options.resolvePriority
+            : (options.resolvePriority[project.name] ?? 'source'),
+        root: project.dir,
+      },
+    ]),
+  );
+}

--- a/src/source-build/rspack-plugin.ts
+++ b/src/source-build/rspack-plugin.ts
@@ -1,0 +1,624 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Compiler, NormalModuleFactory, ResolveData } from '@rspack/core';
+import {
+  DependencyResolverTracker,
+  type TrackedDependencyResolveData,
+} from './dependency-resolver-tracker.js';
+import {
+  getPackageRequestName,
+  getSourceBuildPackage,
+  PLUGIN_SOURCE_BUILD_RESOLVER_NAME,
+  type SourceBuildPackage,
+  type SourceBuildPackages,
+} from './resolve.js';
+
+const NATIVE_RESOLUTION = Symbol('native-resolution');
+const FIRST_PLUGIN_STAGE = Number.MIN_SAFE_INTEGER;
+const LAST_PLUGIN_STAGE = Number.MAX_SAFE_INTEGER;
+
+type RspackResolver = ReturnType<NormalModuleFactory['getResolver']>;
+type RspackResolveOptions = Parameters<NormalModuleFactory['getResolver']>[1];
+type CallbackResolver = (
+  context: string,
+  request: string,
+  callback: (error: Error | null, result?: string | false) => void,
+) => void;
+type ScopedResolution = string | undefined | typeof NATIVE_RESOLUTION;
+type AsyncResolver = (
+  context: string,
+  request: string,
+) => Promise<string | false>;
+type ScopedRequestResolver = (
+  context: string,
+  request: string,
+) => Promise<ScopedResolution>;
+type ExternalGetResolve = (options?: RspackResolveOptions) => CallbackResolver;
+
+type ResolverFactory = {
+  get(type: string, resolveOptions: RspackResolveOptions): RspackResolver;
+};
+
+interface DependencyResolveData extends TrackedDependencyResolveData {
+  dependencyType?: string;
+  /** Available in newer Rspack runtimes, but absent from Rspack 1.x. */
+  getResolve?: ExternalGetResolve;
+}
+
+/**
+ * Gets a normal resolver across the supported Rspack APIs.
+ *
+ * @remarks
+ * Newer Rspack versions expose `NormalModuleFactory.getResolver`, while Rspack
+ * 1.x requires using `Compilation.resolverFactory`.
+ */
+export function getNormalResolver(
+  normalModuleFactory: Pick<NormalModuleFactory, 'getResolver'>,
+  compilation: { resolverFactory: ResolverFactory },
+  resolveOptions: RspackResolveOptions = { alias: false },
+): RspackResolver {
+  if (typeof normalModuleFactory.getResolver === 'function') {
+    return normalModuleFactory.getResolver('normal', resolveOptions);
+  }
+
+  return compilation.resolverFactory.get('normal', resolveOptions);
+}
+
+/**
+ * Appends resolver dependencies that are not already present in ResolveData.
+ *
+ * @remarks
+ * This supports the Rspack 1.x fallback in {@link resolveCandidate}, whose
+ * manually invoked resolver cannot register its dependencies through
+ * `ExternalItemFunctionData.getResolve`.
+ */
+function mergeDependencies(target: string[], source: Set<string>): void {
+  for (const dependency of source) {
+    if (!target.includes(dependency)) {
+      target.push(dependency);
+    }
+  }
+}
+
+function resolveWithCallback(
+  resolver: CallbackResolver,
+  context: string,
+  request: string,
+): Promise<string | false> {
+  return new Promise((resolve, reject) => {
+    resolver(context, request, (error, result) => {
+      if (error) {
+        reject(error);
+      } else if (result === undefined) {
+        reject(
+          new Error(
+            `[${PLUGIN_SOURCE_BUILD_RESOLVER_NAME}] Unable to resolve "${request}".`,
+          ),
+        );
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+/**
+ * Resolves a request and propagates its resolution dependencies to Rspack.
+ *
+ * @remarks
+ * Rspack 1.x does not provide `getResolve` to an externals callback. The plugin
+ * therefore invokes `resolverFactory` directly and copies file, context, and
+ * missing dependencies back to ResolveData so watch invalidation matches native
+ * resolution.
+ */
+async function resolveCandidate(
+  resolver: RspackResolver,
+  data: ResolveData,
+  candidate: string,
+): Promise<string | false> {
+  const fileDependencies = new Set(data.fileDependencies);
+  const contextDependencies = new Set(data.contextDependencies);
+  const missingDependencies = new Set(data.missingDependencies);
+
+  try {
+    return await new Promise<string | false>((resolve, reject) => {
+      resolver.resolve(
+        {},
+        data.context,
+        candidate,
+        {
+          fileDependencies,
+          contextDependencies,
+          missingDependencies,
+        },
+        (error, result) => {
+          if (error) {
+            reject(error);
+          } else if (result === undefined) {
+            reject(
+              new Error(
+                `[${PLUGIN_SOURCE_BUILD_RESOLVER_NAME}] Unable to resolve "${candidate}".`,
+              ),
+            );
+          } else {
+            resolve(result);
+          }
+        },
+      );
+    });
+  } finally {
+    mergeDependencies(data.fileDependencies, fileDependencies);
+    mergeDependencies(data.contextDependencies, contextDependencies);
+    mergeDependencies(data.missingDependencies, missingDependencies);
+  }
+}
+
+function realpath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+const packageRootCache = new WeakMap<SourceBuildPackage, string>();
+const packageRootIndexCache = new WeakMap<
+  SourceBuildPackages,
+  Map<string, SourceBuildPackage>
+>();
+
+function getPackageRoot(sourceBuildPackage: SourceBuildPackage): string {
+  let packageRoot = packageRootCache.get(sourceBuildPackage);
+  if (!packageRoot) {
+    packageRoot = realpath(sourceBuildPackage.root);
+    packageRootCache.set(sourceBuildPackage, packageRoot);
+  }
+  return packageRoot;
+}
+
+function getPackageRootIndex(
+  packages: SourceBuildPackages,
+): Map<string, SourceBuildPackage> {
+  let packageRootIndex = packageRootIndexCache.get(packages);
+  if (!packageRootIndex) {
+    packageRootIndex = new Map(
+      Array.from(packages.values(), (sourceBuildPackage) => [
+        getPackageRoot(sourceBuildPackage),
+        sourceBuildPackage,
+      ]),
+    );
+    packageRootIndexCache.set(packages, packageRootIndex);
+  }
+  return packageRootIndex;
+}
+
+function getResolvedResource(resolved: string): string {
+  const escapedHash = '\0source-build-hash\0';
+  return resolved
+    .replaceAll('\u200b#', escapedHash)
+    .split(/[?#]/, 1)[0]
+    .replaceAll(escapedHash, '#');
+}
+
+function isInsidePackage(
+  resolved: string | false,
+  sourceBuildPackage: SourceBuildPackage,
+): boolean {
+  if (resolved === false) {
+    return false;
+  }
+
+  const packageRoot = getPackageRoot(sourceBuildPackage);
+  const relative = path.relative(
+    packageRoot,
+    realpath(getResolvedResource(resolved)),
+  );
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
+  );
+}
+
+function getScopedResolveOptions(
+  resolvePriority: SourceBuildPackage['resolvePriority'],
+  sourceField: string,
+  dependencyType?: string,
+): RspackResolveOptions {
+  return {
+    conditionNames: [sourceField, '...'],
+    dependencyType,
+    mainFields:
+      resolvePriority === 'source'
+        ? [sourceField, '...']
+        : ['...', sourceField],
+  };
+}
+
+function getResolvedSourceBuildPackage(
+  resolved: string | false,
+  packages: SourceBuildPackages,
+): SourceBuildPackage | undefined {
+  if (resolved === false) {
+    return;
+  }
+
+  const packageRootIndex = getPackageRootIndex(packages);
+  let currentPath = realpath(getResolvedResource(resolved));
+  while (true) {
+    const sourceBuildPackage = packageRootIndex.get(currentPath);
+    if (sourceBuildPackage) {
+      return sourceBuildPackage;
+    }
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) {
+      return;
+    }
+    currentPath = parentPath;
+  }
+}
+
+async function resolveScopedRequest(
+  request: string,
+  packages: SourceBuildPackages,
+  resolveNative: () => Promise<string | false>,
+  resolveSourceBuild: (
+    resolvePriority: SourceBuildPackage['resolvePriority'],
+  ) => Promise<string | false>,
+): Promise<ScopedResolution> {
+  if (!getPackageRequestName(request)) {
+    return;
+  }
+
+  let sourceBuildPackage: SourceBuildPackage | undefined;
+  try {
+    sourceBuildPackage = getResolvedSourceBuildPackage(
+      await resolveNative(),
+      packages,
+    );
+    if (!sourceBuildPackage) {
+      return NATIVE_RESOLUTION;
+    }
+  } catch {
+    sourceBuildPackage = getSourceBuildPackage(request, packages);
+  }
+
+  if (sourceBuildPackage) {
+    try {
+      const resolved = await resolveSourceBuild(
+        sourceBuildPackage.resolvePriority,
+      );
+      return resolved !== false && isInsidePackage(resolved, sourceBuildPackage)
+        ? resolved
+        : NATIVE_RESOLUTION;
+    } catch {
+      return NATIVE_RESOLUTION;
+    }
+  }
+
+  // Native resolution can fail for an alias to a source-only selected package.
+  // Probe both field orders to discover the aliased project, then honor that
+  // project's configured priority while retaining the successful probe as its
+  // fallback when the preferred entry does not exist.
+  for (const probePriority of ['source', 'output'] as const) {
+    try {
+      const resolved = await resolveSourceBuild(probePriority);
+      if (resolved === false) {
+        continue;
+      }
+      const resolvedPackage = getResolvedSourceBuildPackage(resolved, packages);
+      if (!resolvedPackage) {
+        continue;
+      }
+      if (resolvedPackage.resolvePriority === probePriority) {
+        return resolved;
+      }
+
+      try {
+        const preferred = await resolveSourceBuild(
+          resolvedPackage.resolvePriority,
+        );
+        if (
+          preferred !== false &&
+          isInsidePackage(preferred, resolvedPackage)
+        ) {
+          return preferred;
+        }
+      } catch {
+        // The successful probe is the package's configured fallback.
+      }
+      return resolved;
+    } catch {
+      // Try the next priority before falling back to native diagnostics.
+    }
+  }
+  return NATIVE_RESOLUTION;
+}
+
+function createScopedRequestResolver(options: {
+  packages: SourceBuildPackages;
+  resolveNative: AsyncResolver;
+  createSourceBuildResolver: (
+    resolvePriority: SourceBuildPackage['resolvePriority'],
+  ) => AsyncResolver;
+}): ScopedRequestResolver {
+  const { createSourceBuildResolver, packages, resolveNative } = options;
+  const scopedResolvers = new Map<
+    SourceBuildPackage['resolvePriority'],
+    AsyncResolver
+  >();
+
+  return (context, request) =>
+    resolveScopedRequest(
+      request,
+      packages,
+      () => resolveNative(context, request),
+      (resolvePriority) => {
+        let resolver = scopedResolvers.get(resolvePriority);
+        if (!resolver) {
+          resolver = createSourceBuildResolver(resolvePriority);
+          scopedResolvers.set(resolvePriority, resolver);
+        }
+        return resolver(context, request);
+      },
+    );
+}
+
+function createLoaderResolveOptions(
+  options: Record<string, unknown> | undefined,
+  resolvePriority: SourceBuildPackage['resolvePriority'],
+  sourceField: string,
+): Record<string, unknown> {
+  const conditionNames = Array.isArray(options?.conditionNames)
+    ? options.conditionNames
+    : ['...'];
+  const mainFields = Array.isArray(options?.mainFields)
+    ? options.mainFields
+    : ['...'];
+
+  return {
+    ...options,
+    conditionNames: [sourceField, ...conditionNames],
+    mainFields:
+      resolvePriority === 'source'
+        ? [sourceField, ...mainFields]
+        : [...mainFields, sourceField],
+  };
+}
+
+/**
+ * Captures the dependency-specific resolver context before factorization.
+ *
+ * @remarks
+ * Newer Rspack versions provide the exact `getResolve` function, preserving
+ * rule-level and `byDependency` options. Rspack 1.x only provides the dependency
+ * type, which is consumed by the resolverFactory compatibility fallback. The
+ * no-op external is installed after user externals at the default factorize
+ * stage, immediately before the scoped tap registered by the earliest
+ * `thisCompilation` handler. This lets {@link DependencyResolverTracker}
+ * serialize otherwise indistinguishable concurrent requests.
+ */
+function applyDependencyResolverTracker(
+  compiler: Compiler,
+): DependencyResolverTracker<DependencyResolveData> {
+  const tracker = new DependencyResolverTracker<DependencyResolveData>();
+
+  const applyTracker = () => {
+    // ResolveData omits dependencyType and rule/byDependency resolve options.
+    // A no-op external receives Rspack's exact getResolve function before the
+    // scoped factorize tap; returning no result never externalizes a module.
+    new compiler.rspack.ExternalsPlugin(
+      'commonjs',
+      (data: DependencyResolveData, callback: (error?: Error) => void) => {
+        tracker.add(data, callback);
+      },
+    ).apply(compiler);
+  };
+
+  if (compiler.isChild()) {
+    // Child compiler registration runs from Compilation.childCompiler after
+    // its inherited and explicitly supplied plugins have already been applied.
+    applyTracker();
+  } else {
+    // Install the tracker after other compiler plugins so its default-stage
+    // externals tap is immediately followed by our factorize tap.
+    compiler.hooks.afterPlugins.tap(
+      {
+        name: PLUGIN_SOURCE_BUILD_RESOLVER_NAME,
+        stage: LAST_PLUGIN_STAGE,
+      },
+      applyTracker,
+    );
+  }
+  return tracker;
+}
+
+function registerRspackCompiler(
+  compiler: Compiler,
+  packages: SourceBuildPackages,
+  sourceField: string,
+  registeredCompilers: WeakSet<Compiler>,
+): void {
+  if (registeredCompilers.has(compiler)) {
+    return;
+  }
+  registeredCompilers.add(compiler);
+
+  const dependencyResolvers = applyDependencyResolverTracker(compiler);
+
+  compiler.hooks.thisCompilation.tap(
+    {
+      name: PLUGIN_SOURCE_BUILD_RESOLVER_NAME,
+      stage: FIRST_PLUGIN_STAGE,
+    },
+    (compilation, { normalModuleFactory }) => {
+      // A compiler reuses this tracker across watch compilations. Entries that
+      // were not consumed because factorization bailed must not cross the
+      // compilation boundary.
+      dependencyResolvers.clear();
+
+      const applyScopedResolution = async (
+        data: ResolveData,
+        dependencyData?: DependencyResolveData,
+      ): Promise<void> => {
+        const externalGetResolve = dependencyData?.getResolve;
+        const nativeResolver = externalGetResolve
+          ? externalGetResolve()
+          : getNormalResolver(normalModuleFactory, compilation, {
+              dependencyType: dependencyData?.dependencyType,
+            });
+        const resolve = createScopedRequestResolver({
+          packages,
+          resolveNative: externalGetResolve
+            ? (context, request) =>
+                resolveWithCallback(
+                  nativeResolver as CallbackResolver,
+                  context,
+                  request,
+                )
+            : (_context, request) =>
+                resolveCandidate(
+                  nativeResolver as RspackResolver,
+                  data,
+                  request,
+                ),
+          createSourceBuildResolver: (resolvePriority) => {
+            const resolveOptions = getScopedResolveOptions(
+              resolvePriority,
+              sourceField,
+              dependencyData?.dependencyType,
+            );
+            if (externalGetResolve) {
+              const callbackResolver = externalGetResolve(resolveOptions);
+              return (context, request) =>
+                resolveWithCallback(callbackResolver, context, request);
+            }
+
+            const rspackResolver = getNormalResolver(
+              normalModuleFactory,
+              compilation,
+              resolveOptions,
+            );
+            return (_context, request) =>
+              resolveCandidate(rspackResolver, data, request);
+          },
+        });
+        const resolved = await resolve(data.context, data.request);
+
+        if (typeof resolved === 'string') {
+          data.request = resolved;
+        }
+      };
+
+      normalModuleFactory.hooks.factorize.tapPromise(
+        PLUGIN_SOURCE_BUILD_RESOLVER_NAME,
+        async (data) => {
+          const trackedRequest = data.request;
+          const trackedIssuer = data.contextInfo.issuer;
+          const dependencyData = dependencyResolvers.get(
+            data.context,
+            trackedRequest,
+            trackedIssuer,
+          );
+          try {
+            await applyScopedResolution(data, dependencyData);
+          } finally {
+            dependencyResolvers.release(
+              data.context,
+              trackedRequest,
+              trackedIssuer,
+            );
+          }
+        },
+      );
+
+      const { NormalModule } = compiler.rspack;
+      NormalModule.getCompilationHooks(compilation).loader.tap(
+        PLUGIN_SOURCE_BUILD_RESOLVER_NAME,
+        (loaderContext) => {
+          const getResolve = loaderContext.getResolve.bind(loaderContext);
+
+          loaderContext.getResolve = ((options) => {
+            const nativeResolver = getResolve(options) as CallbackResolver;
+            const resolve = createScopedRequestResolver({
+              packages,
+              resolveNative: (context, request) =>
+                resolveWithCallback(nativeResolver, context, request),
+              createSourceBuildResolver: (resolvePriority) => {
+                const resolver = getResolve(
+                  createLoaderResolveOptions(
+                    options as Record<string, unknown> | undefined,
+                    resolvePriority,
+                    sourceField,
+                  ),
+                ) as CallbackResolver;
+                return (context, request) =>
+                  resolveWithCallback(resolver, context, request);
+              },
+            });
+
+            const resolveWithNativeFallback = async (
+              context: string,
+              request: string,
+            ): Promise<string | false> => {
+              const resolved = await resolve(context, request);
+
+              if (resolved === NATIVE_RESOLUTION || resolved === undefined) {
+                return resolveWithCallback(nativeResolver, context, request);
+              }
+              return resolved;
+            };
+
+            return (
+              context: string,
+              request: string,
+              callback?: (error: Error | null, result?: string | false) => void,
+            ) => {
+              const promise = resolveWithNativeFallback(context, request);
+              if (callback) {
+                promise.then(
+                  (result) => callback(null, result),
+                  (error) => callback(error as Error),
+                );
+                return;
+              }
+              return promise;
+            };
+          }) as typeof loaderContext.getResolve;
+        },
+      );
+
+      compilation.hooks.childCompiler?.tap(
+        {
+          name: PLUGIN_SOURCE_BUILD_RESOLVER_NAME,
+          stage: LAST_PLUGIN_STAGE,
+        },
+        (childCompiler) => {
+          registerRspackCompiler(
+            childCompiler,
+            packages,
+            sourceField,
+            registeredCompilers,
+          );
+        },
+      );
+    },
+  );
+}
+
+export class SourceBuildResolverPlugin {
+  name = PLUGIN_SOURCE_BUILD_RESOLVER_NAME;
+
+  constructor(
+    private readonly packages: SourceBuildPackages,
+    private readonly sourceField: string,
+  ) {}
+
+  apply(compiler: Compiler): void {
+    registerRspackCompiler(
+      compiler,
+      this.packages,
+      this.sourceField,
+      new WeakSet(),
+    );
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,8 +4,13 @@ import type { IsMonorepoFn } from '../common/isMonorepo.js';
 export * from './packageJson.js';
 export * from './rushJson.js';
 
+/**
+ * Adapter contract for discovering projects in a custom monorepo format.
+ */
 export interface MonorepoAnalyzer {
+  /** Returns whether the given directory is the root of this monorepo type. */
   check: IsMonorepoFn;
+  /** Returns every workspace project managed by this monorepo root. */
   getProjects: GetProjectsFunc;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,7 +5,9 @@ import { createRsbuild, loadConfig } from '@rsbuild/core';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('should build succeed', async ({ page }) => {
+test('should build dependent workspace packages from source', async ({
+  page,
+}) => {
   const cwd = join(__dirname, 'app');
   const rsbuild = await createRsbuild({
     cwd,

--- a/test/source-build-adapter.test.ts
+++ b/test/source-build-adapter.test.ts
@@ -1,0 +1,387 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { createRsbuild, type RsbuildPlugin } from '@rsbuild/core';
+import { afterEach, expect, test } from '@rstest/core';
+import {
+  type ExtraMonorepoStrategies,
+  type MonorepoAnalyzer,
+  pluginSourceBuild,
+  Project,
+} from '../src/index.js';
+
+const loadModule = createRequire(import.meta.url);
+const temporaryDirectories: string[] = [];
+
+function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(message)), 10_000);
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+function writeFiles(root: string, files: Record<string, string>): void {
+  for (const [file, content] of Object.entries(files)) {
+    const filePath = path.join(root, file);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+async function createProject(
+  root: string,
+  name: string,
+  packageJson: Record<string, unknown>,
+  files: Record<string, string>,
+): Promise<Project> {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name, ...packageJson }),
+  );
+  writeFiles(root, files);
+
+  const project = new Project(name, root);
+  await project.init();
+  return project;
+}
+
+function linkPackage(appRoot: string, project: Project): void {
+  const packageLink = path.join(appRoot, 'node_modules', project.name);
+  fs.mkdirSync(path.dirname(packageLink), { recursive: true });
+  fs.symlinkSync(
+    project.dir,
+    packageLink,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test('uses adapter projects and package dependencies as the source-build boundary', async () => {
+  const monorepoRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'source-build-adapter-'),
+  );
+  temporaryDirectories.push(monorepoRoot);
+
+  const appRoot = path.join(monorepoRoot, 'app');
+  const selected = await createProject(
+    path.join(monorepoRoot, 'selected'),
+    '@test/selected',
+    {
+      exports: {
+        '.': {
+          source: './src/index.js',
+          require: './dist/index.js',
+        },
+      },
+    },
+    {
+      'src/index.js': `module.exports = 'selected-source';`,
+      'dist/index.js': `module.exports = 'selected-dist';`,
+      'tsconfig.json': JSON.stringify({ compilerOptions: { composite: true } }),
+    },
+  );
+  const workspaceOnly = await createProject(
+    path.join(monorepoRoot, 'workspace-only'),
+    '@test/workspace-only',
+    {
+      exports: {
+        '.': {
+          source: './src/index.js',
+          require: './dist/index.js',
+        },
+      },
+    },
+    {
+      'src/index.js': `module.exports = 'workspace-source';`,
+      'dist/index.js': `module.exports = 'workspace-dist';`,
+    },
+  );
+  const conditional = await createProject(
+    path.join(monorepoRoot, 'conditional'),
+    '@test/conditional',
+    {
+      exports: {
+        '.': {
+          node: {
+            require: {
+              source: './src/index.js',
+              default: './dist/index.js',
+            },
+          },
+        },
+      },
+    },
+    {
+      'src/index.js': `module.exports = 'conditional-source';`,
+      'dist/index.js': `module.exports = 'conditional-dist';`,
+    },
+  );
+  const referencedOnly = await createProject(
+    path.join(monorepoRoot, 'referenced-only'),
+    '@test/referenced-only',
+    {
+      exports: {
+        '.': {
+          source: './src/index.js',
+          require: './dist/index.js',
+        },
+      },
+    },
+    {
+      'src/index.js': `module.exports = 'referenced-source';`,
+      'dist/index.js': `module.exports = 'referenced-dist';`,
+      'tsconfig.json': JSON.stringify({ compilerOptions: { composite: true } }),
+    },
+  );
+  const app = await createProject(
+    appRoot,
+    '@test/app',
+    {
+      private: true,
+      dependencies: {
+        [selected.name]: 'workspace:*',
+        [conditional.name]: 'workspace:*',
+        '@test/external': '1.0.0',
+        '@test/external-main': '1.0.0',
+      },
+    },
+    {
+      'src/index.js': `module.exports = [
+        require('${selected.name}'),
+        require('${conditional.name}'),
+        require('${workspaceOnly.name}'),
+        require('${referencedOnly.name}'),
+        require('@test/external'),
+        require('@test/external-main'),
+      ];`,
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {},
+        references: [{ path: '../referenced-only/tsconfig.json' }],
+      }),
+    },
+  );
+
+  for (const project of [
+    selected,
+    conditional,
+    workspaceOnly,
+    referencedOnly,
+  ]) {
+    linkPackage(appRoot, project);
+  }
+  writeFiles(path.join(appRoot, 'node_modules/@test/external'), {
+    'package.json': JSON.stringify({
+      name: '@test/external',
+      exports: {
+        '.': {
+          source: './src/index.js',
+          require: './dist/index.js',
+        },
+      },
+    }),
+    'src/index.js': `module.exports = 'external-source';`,
+    'dist/index.js': `module.exports = 'external-dist';`,
+  });
+  writeFiles(path.join(appRoot, 'node_modules/@test/external-main'), {
+    'package.json': JSON.stringify({
+      name: '@test/external-main',
+      source: './src/index.js',
+      main: './dist/index.js',
+    }),
+    'src/index.js': `module.exports = 'external-main-source';`,
+    'dist/index.js': `module.exports = 'external-main-dist';`,
+  });
+
+  const projects = [app, selected, conditional, workspaceOnly, referencedOnly];
+  const adapter: MonorepoAnalyzer = {
+    check: (root) => root === monorepoRoot,
+    getProjects: async () => projects,
+  };
+  const extraMonorepoStrategies: ExtraMonorepoStrategies = {
+    test: adapter,
+  };
+  const rsbuild = await createRsbuild({
+    cwd: appRoot,
+    rsbuildConfig: {
+      mode: 'development',
+      source: { entry: { index: './src/index.js' } },
+      output: {
+        target: 'node',
+        distPath: { root: 'dist' },
+        filename: { js: '[name].js' },
+      },
+      plugins: [
+        pluginSourceBuild({
+          projectName: app.name,
+          extraMonorepoStrategies,
+        }),
+      ],
+      tools: {
+        rspack: {
+          output: { library: { type: 'commonjs2' } },
+        },
+      },
+    },
+  });
+
+  await rsbuild.build();
+
+  const bundlePath = path.join(appRoot, 'dist/index.js');
+  delete loadModule.cache[bundlePath];
+  expect(loadModule(bundlePath)).toEqual([
+    'selected-source',
+    'conditional-source',
+    'workspace-dist',
+    'referenced-dist',
+    'external-dist',
+    'external-main-dist',
+  ]);
+});
+
+test('tracks resolved workspace source without adding source.include', async () => {
+  const monorepoRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'source-build-watch-'),
+  );
+  temporaryDirectories.push(monorepoRoot);
+
+  const appRoot = path.join(monorepoRoot, 'app');
+  const selected = await createProject(
+    path.join(monorepoRoot, 'selected'),
+    '@test/watched-source',
+    {
+      source: './src/before.js',
+      main: './dist/index.js',
+    },
+    {
+      'src/before.js': `module.exports = 'source-before';`,
+      'src/after.js': `module.exports = 'source-after';`,
+      'dist/index.js': `module.exports = 'dist';`,
+    },
+  );
+  const app = await createProject(
+    appRoot,
+    '@test/watch-app',
+    {
+      private: true,
+      dependencies: { [selected.name]: 'workspace:*' },
+    },
+    {
+      'src/index.js': `module.exports = require('${selected.name}');`,
+      'tsconfig.json': JSON.stringify({ compilerOptions: {} }),
+    },
+  );
+  linkPackage(appRoot, selected);
+
+  let resolveFirstBuild!: () => void;
+  let resolveSecondBuild!: () => void;
+  let resolveThirdBuild!: () => void;
+  const firstBuild = new Promise<void>((resolve) => {
+    resolveFirstBuild = resolve;
+  });
+  const secondBuild = new Promise<void>((resolve) => {
+    resolveSecondBuild = resolve;
+  });
+  const thirdBuild = new Promise<void>((resolve) => {
+    resolveThirdBuild = resolve;
+  });
+  const bundlePath = path.join(appRoot, 'dist/index.js');
+  const expectedBuilds = new Map<string, () => void>([
+    ['source-before', resolveFirstBuild],
+    ['source-after', resolveSecondBuild],
+    ['source-after-updated', resolveThirdBuild],
+  ]);
+  const observeBuilds: RsbuildPlugin = {
+    name: 'test:observe-source-builds',
+    setup(api) {
+      api.onAfterBuild(() => {
+        try {
+          delete loadModule.cache[bundlePath];
+          const result = loadModule(bundlePath) as string;
+          expectedBuilds.get(result)?.();
+        } catch {
+          // The assertion below reports a useful error if the build never emits.
+        }
+      });
+    },
+  };
+  const adapter: MonorepoAnalyzer = {
+    check: (root) => root === monorepoRoot,
+    getProjects: async () => [app, selected],
+  };
+  const rsbuild = await createRsbuild({
+    cwd: appRoot,
+    rsbuildConfig: {
+      mode: 'development',
+      source: { entry: { index: './src/index.js' } },
+      output: {
+        target: 'node',
+        distPath: { root: 'dist' },
+        filename: { js: '[name].js' },
+      },
+      plugins: [
+        pluginSourceBuild({
+          projectName: app.name,
+          extraMonorepoStrategies: { test: adapter },
+        }),
+        observeBuilds,
+      ],
+      tools: {
+        rspack: {
+          output: { library: { type: 'commonjs2' } },
+        },
+      },
+    },
+  });
+
+  const buildResult = await rsbuild.build({ watch: true });
+  try {
+    await withTimeout(firstBuild, 'Timed out waiting for the initial build.');
+    expect(rsbuild.getNormalizedConfig().source.include).toBeUndefined();
+    delete loadModule.cache[bundlePath];
+    expect(loadModule(bundlePath)).toBe('source-before');
+
+    fs.writeFileSync(
+      path.join(selected.dir, 'package.json'),
+      JSON.stringify({
+        name: selected.name,
+        source: './src/after.js',
+        main: './dist/index.js',
+      }),
+    );
+    await withTimeout(
+      secondBuild,
+      'Timed out waiting for the package metadata rebuild.',
+    );
+    delete loadModule.cache[bundlePath];
+    expect(loadModule(bundlePath)).toBe('source-after');
+
+    fs.writeFileSync(
+      path.join(selected.dir, 'src/after.js'),
+      `module.exports = 'source-after-updated';`,
+    );
+    await withTimeout(
+      thirdBuild,
+      'Timed out waiting for the workspace source rebuild.',
+    );
+    delete loadModule.cache[bundlePath];
+    expect(loadModule(bundlePath)).toBe('source-after-updated');
+  } finally {
+    await buildResult.close();
+  }
+});

--- a/test/source-build-resolver.test.ts
+++ b/test/source-build-resolver.test.ts
@@ -1,0 +1,197 @@
+import path from 'node:path';
+import type { NormalModuleFactory } from '@rspack/core';
+import { describe, expect, rs, test } from '@rstest/core';
+import { pluginSourceBuild } from '../src/plugin.js';
+import { Project } from '../src/project.js';
+import { DependencyResolverTracker } from '../src/source-build/dependency-resolver-tracker.js';
+import { getNormalResolver } from '../src/source-build/rspack-plugin.js';
+import {
+  createSourceBuildPackages,
+  getSourceBuildPackage,
+  type SourceBuildPackage,
+} from '../src/source-build/resolve.js';
+
+const PACKAGE_NAME = '@test/source';
+const PACKAGE_ROOT = path.resolve('/workspace/source');
+
+type BundlerChainCallback = (chain: unknown, utils: unknown) => unknown;
+
+describe('source-build package boundary', () => {
+  const sourceBuildPackage: SourceBuildPackage = {
+    resolvePriority: 'source',
+    root: PACKAGE_ROOT,
+  };
+  const packages = new Map([[PACKAGE_NAME, sourceBuildPackage]]);
+
+  test('matches configured package roots and subpaths only', () => {
+    expect(getSourceBuildPackage(PACKAGE_NAME, packages)).toBe(
+      sourceBuildPackage,
+    );
+    expect(
+      getSourceBuildPackage(`${PACKAGE_NAME}/theme.css?raw`, packages),
+    ).toBe(sourceBuildPackage);
+    expect(getSourceBuildPackage('@test/external', packages)).toBeUndefined();
+    expect(getSourceBuildPackage('./local', packages)).toBeUndefined();
+    expect(
+      getSourceBuildPackage('/workspace/source/src/index.ts', packages),
+    ).toBeUndefined();
+  });
+
+  test('retains the selected project root and global resolve priority', () => {
+    const project = new Project(PACKAGE_NAME, PACKAGE_ROOT);
+
+    expect(
+      createSourceBuildPackages([project], { resolvePriority: 'output' }),
+    ).toEqual(
+      new Map([
+        [
+          PACKAGE_NAME,
+          {
+            resolvePriority: 'output',
+            root: PACKAGE_ROOT,
+          },
+        ],
+      ]),
+    );
+  });
+
+  test('supports per-package resolve priority overrides', () => {
+    const sourceProject = new Project(PACKAGE_NAME, PACKAGE_ROOT);
+    const outputProject = new Project(
+      '@test/output',
+      path.resolve('/workspace/output'),
+    );
+
+    expect(
+      createSourceBuildPackages([sourceProject, outputProject], {
+        resolvePriority: {
+          [outputProject.name]: 'output',
+        },
+      }),
+    ).toEqual(
+      new Map([
+        [
+          PACKAGE_NAME,
+          {
+            resolvePriority: 'source',
+            root: PACKAGE_ROOT,
+          },
+        ],
+        [
+          outputProject.name,
+          {
+            resolvePriority: 'output',
+            root: outputProject.dir,
+          },
+        ],
+      ]),
+    );
+  });
+});
+
+describe('plugin configuration', () => {
+  test('rejects invalid resolve priority values at plugin creation', () => {
+    expect(() =>
+      pluginSourceBuild({
+        resolvePriority: { [PACKAGE_NAME]: 'Source' } as never,
+      }),
+    ).toThrow('Invalid resolvePriority for "@test/source"');
+
+    expect(() =>
+      pluginSourceBuild({ resolvePriority: 'invalid' as never }),
+    ).toThrow('Invalid resolvePriority for "resolvePriority"');
+  });
+
+  test('rejects per-package resolve priority outside Rspack', () => {
+    const callbacks: BundlerChainCallback[] = [];
+    const plugin = pluginSourceBuild({
+      resolvePriority: { [PACKAGE_NAME]: 'source' },
+    });
+
+    plugin.setup({
+      context: {
+        bundlerType: 'webpack',
+        rootPath: PACKAGE_ROOT,
+      },
+      modifyBundlerChain: (callback: BundlerChainCallback) => {
+        callbacks.push(callback);
+      },
+    } as never);
+
+    expect(() => callbacks[0]({}, {})).toThrow(
+      'Per-package resolvePriority is only supported with Rspack.',
+    );
+  });
+});
+
+describe('getNormalResolver', () => {
+  const resolver = {
+    resolve: rs.fn(),
+  } as unknown as ReturnType<NormalModuleFactory['getResolver']>;
+
+  test('uses the normal module factory resolver when available', () => {
+    const nativeGet = rs.fn(() => resolver);
+    const fallbackGet = rs.fn(() => resolver);
+
+    expect(
+      getNormalResolver(
+        { getResolver: nativeGet } as Pick<NormalModuleFactory, 'getResolver'>,
+        { resolverFactory: { get: fallbackGet } },
+      ),
+    ).toBe(resolver);
+    expect(nativeGet).toHaveBeenCalledWith('normal', { alias: false });
+    expect(fallbackGet).not.toHaveBeenCalled();
+  });
+
+  test('falls back to the compilation resolver factory', () => {
+    const fallbackGet = rs.fn(() => resolver);
+
+    expect(
+      getNormalResolver({} as Pick<NormalModuleFactory, 'getResolver'>, {
+        resolverFactory: { get: fallbackGet },
+      }),
+    ).toBe(resolver);
+    expect(fallbackGet).toHaveBeenCalledWith('normal', { alias: false });
+  });
+});
+
+describe('DependencyResolverTracker', () => {
+  test('serializes concurrent dependency resolvers with the same request key', () => {
+    const tracker = new DependencyResolverTracker();
+    const resumed: string[] = [];
+    const baseData = {
+      context: '/workspace/app',
+      contextInfo: { issuer: '/workspace/app/src/index.js' },
+      request: PACKAGE_NAME,
+    };
+    const esmData = { ...baseData, dependencyType: 'esm' };
+    const commonJsData = { ...baseData, dependencyType: 'commonjs' };
+
+    tracker.add(esmData, () => resumed.push('esm'));
+    tracker.add(commonJsData, () => resumed.push('commonjs'));
+
+    expect(resumed).toEqual(['esm']);
+    expect(
+      tracker.get(
+        baseData.context,
+        baseData.request,
+        baseData.contextInfo.issuer,
+      ),
+    ).toBe(esmData);
+
+    tracker.release(
+      baseData.context,
+      baseData.request,
+      baseData.contextInfo.issuer,
+    );
+
+    expect(resumed).toEqual(['esm', 'commonjs']);
+    expect(
+      tracker.get(
+        baseData.context,
+        baseData.request,
+        baseData.contextInfo.issuer,
+      ),
+    ).toBe(commonJsData);
+  });
+});

--- a/test/source-build-rspack.test.ts
+++ b/test/source-build-rspack.test.ts
@@ -1,0 +1,774 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { type Compiler, rspack, type RspackOptions } from '@rspack/core';
+import { afterEach, describe, expect, test } from '@rstest/core';
+import { Project } from '../src/project.js';
+import { SourceBuildResolverPlugin } from '../src/source-build/rspack-plugin.js';
+import {
+  createSourceBuildPackages,
+  SourceBuildPackage,
+  type SourceBuildPackages,
+} from '../src/source-build/resolve.js';
+
+const temporaryDirectories: string[] = [];
+const loadModule = createRequire(import.meta.url);
+
+type TestAlias = Record<string, string | false | Array<string | false>>;
+
+interface TestPackage {
+  name: string;
+  packageJson: Record<string, unknown>;
+  root: string;
+  sourceBuildPackage: SourceBuildPackage;
+}
+
+async function runCompiler(
+  compiler: NonNullable<ReturnType<typeof rspack>>,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    compiler.run((error, stats) => {
+      compiler.close(() => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (!stats || stats.hasErrors()) {
+          reject(
+            new Error(
+              stats?.toString({ all: false, errors: true }) ??
+                'Rspack compilation failed',
+            ),
+          );
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+}
+
+function writeFiles(root: string, files: Record<string, string>): void {
+  for (const [file, content] of Object.entries(files)) {
+    const filePath = path.join(root, file);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+function createTestPackage(
+  fixtureRoot: string,
+  name: string,
+  packageJson: Record<string, unknown>,
+  files: Record<string, string>,
+): TestPackage {
+  const root = path.join(fixtureRoot, 'workspace', name.replace('/', '__'));
+  fs.mkdirSync(root, { recursive: true });
+  const completePackageJson = {
+    name,
+    ...packageJson,
+  };
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify(completePackageJson),
+  );
+  writeFiles(root, files);
+
+  return {
+    name,
+    packageJson: completePackageJson,
+    root,
+    sourceBuildPackage: {
+      resolvePriority: 'source',
+      root,
+    },
+  };
+}
+
+function createPackages(...packages: TestPackage[]): SourceBuildPackages {
+  return new Map(packages.map((item) => [item.name, item.sourceBuildPackage]));
+}
+
+function linkPackage(appRoot: string, testPackage: TestPackage): void {
+  const packageLink = path.join(appRoot, 'node_modules', testPackage.name);
+  fs.mkdirSync(path.dirname(packageLink), { recursive: true });
+  fs.symlinkSync(
+    testPackage.root,
+    packageLink,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+}
+
+async function compileRequests(
+  appRoot: string,
+  packages: SourceBuildPackages,
+  requests: string[],
+  options?: {
+    alias?: TestAlias;
+    byDependencyAlias?: TestAlias;
+    extensions?: string[];
+    externals?: RspackOptions['externals'];
+    plugins?: Array<(compiler: Compiler) => void>;
+    ruleAlias?: TestAlias;
+    tsConfig?: {
+      configFile: string;
+      references: string[];
+    };
+  },
+): Promise<unknown[]> {
+  const outputPath = path.join(appRoot, 'dist');
+  fs.writeFileSync(
+    path.join(appRoot, 'entry.js'),
+    `module.exports = [${requests
+      .map((request) => `require(${JSON.stringify(request)})`)
+      .join(',')}];`,
+  );
+
+  const compiler = rspack({
+    context: appRoot,
+    entry: './entry.js',
+    externals: options?.externals,
+    mode: 'development',
+    target: 'node',
+    output: {
+      filename: 'bundle.js',
+      library: { type: 'commonjs2' },
+      path: outputPath,
+    },
+    module: options?.ruleAlias
+      ? {
+          rules: [
+            {
+              test: /entry\.js$/,
+              resolve: { alias: options.ruleAlias },
+            },
+          ],
+        }
+      : undefined,
+    plugins: [
+      new SourceBuildResolverPlugin(packages, 'source'),
+      ...(options?.plugins ?? []),
+    ],
+    resolve: {
+      alias: options?.alias,
+      byDependency: options?.byDependencyAlias
+        ? { commonjs: { alias: options.byDependencyAlias } }
+        : undefined,
+      extensions: options?.extensions ?? ['.js', '.ts'],
+      tsConfig: options?.tsConfig,
+    },
+  });
+
+  await runCompiler(compiler);
+
+  const bundlePath = path.join(outputPath, 'bundle.js');
+  delete loadModule.cache[bundlePath];
+  return loadModule(bundlePath) as unknown[];
+}
+
+function createChildCompilerPlugin(packageName: string, mockPath: string) {
+  return (parentCompiler: Compiler) => {
+    parentCompiler.hooks.make.tapAsync(
+      'TestChildCompiler',
+      (compilation, callback) => {
+        const childCompiler = compilation.createChildCompiler(
+          'TestChildCompiler',
+          { filename: 'child.js' },
+          [
+            new (parentCompiler.rspack ?? parentCompiler.webpack).EntryPlugin(
+              parentCompiler.context,
+              './child-entry.js',
+              'child',
+            ),
+          ],
+        );
+        childCompiler.options.resolve.alias = {
+          ...childCompiler.options.resolve.alias,
+          [packageName]: mockPath,
+        };
+        childCompiler.runAsChild((error) => callback(error));
+      },
+    );
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('scoped Rspack source resolution', () => {
+  test('falls back to output when a source-priority entry is missing', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-missing-source-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/missing-source',
+      {
+        source: './src/missing.js',
+        main: './dist/index.js',
+      },
+      { 'dist/index.js': `module.exports = 'output-fallback';` },
+    );
+    linkPackage(appRoot, selectedPackage);
+
+    await expect(
+      compileRequests(appRoot, createPackages(selectedPackage), [
+        selectedPackage.name,
+      ]),
+    ).resolves.toEqual(['output-fallback']);
+  });
+
+  test('falls back to source when an output-priority package has no output entry', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-missing-output-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/missing-output',
+      { source: './src/index.js' },
+      { 'src/index.js': `module.exports = 'source-fallback';` },
+    );
+    linkPackage(appRoot, selectedPackage);
+    const project = new Project(selectedPackage.name, selectedPackage.root);
+    project.metaData = selectedPackage.packageJson;
+    const outputFirstPackages = createSourceBuildPackages([project], {
+      resolvePriority: 'output',
+    });
+
+    await expect(
+      compileRequests(appRoot, outputFirstPackages, [selectedPackage.name]),
+    ).resolves.toEqual(['source-fallback']);
+  });
+
+  test('falls back to an aliased source-only package with output priority', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-aliased-output-priority-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/aliased-source-only',
+      { source: './src/index.js' },
+      { 'src/index.js': `module.exports = 'aliased-source-fallback';` },
+    );
+    selectedPackage.sourceBuildPackage.resolvePriority = 'output';
+    linkPackage(appRoot, selectedPackage);
+
+    await expect(
+      compileRequests(
+        appRoot,
+        createPackages(selectedPackage),
+        ['@test/public-output-entry'],
+        {
+          alias: {
+            '@test/public-output-entry': selectedPackage.name,
+          },
+        },
+      ),
+    ).resolves.toEqual(['aliased-source-fallback']);
+  });
+
+  test('preserves target and dependency conditions inside source exports', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-conditions-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    const outputPath = path.join(appRoot, 'dist');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/conditional-source',
+      {
+        exports: {
+          '.': {
+            browser: {
+              source: './src/browser.js',
+              default: './dist/browser.js',
+            },
+            node: {
+              import: {
+                source: './src/import.mjs',
+                default: './dist/import.mjs',
+              },
+              require: {
+                source: './src/require.js',
+                default: './dist/require.js',
+              },
+            },
+          },
+        },
+      },
+      {
+        'src/browser.js': `module.exports = 'browser-source';`,
+        'dist/browser.js': `module.exports = 'browser-dist';`,
+        'src/import.mjs': `export default 'import-source';`,
+        'dist/import.mjs': `export default 'import-dist';`,
+        'src/require.js': `module.exports = 'require-source';`,
+        'dist/require.js': `module.exports = 'require-dist';`,
+      },
+    );
+    linkPackage(appRoot, selectedPackage);
+    fs.writeFileSync(
+      path.join(appRoot, 'entry.js'),
+      `import imported from '${selectedPackage.name}';
+       export default [imported, require('${selectedPackage.name}')];`,
+    );
+
+    const compiler = rspack({
+      context: appRoot,
+      entry: './entry.js',
+      mode: 'development',
+      target: 'node',
+      output: {
+        filename: 'bundle.js',
+        library: { type: 'commonjs2' },
+        path: outputPath,
+      },
+      plugins: [
+        new SourceBuildResolverPlugin(
+          createPackages(selectedPackage),
+          'source',
+        ),
+      ],
+    });
+
+    await runCompiler(compiler);
+
+    const bundlePath = path.join(outputPath, 'bundle.js');
+    delete loadModule.cache[bundlePath];
+    expect(loadModule(bundlePath).default).toEqual([
+      'import-source',
+      'require-source',
+    ]);
+  });
+
+  test('uses selected workspace packages, not tsconfig references, as the source-build boundary', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-boundary-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/configured',
+      {
+        exports: {
+          '.': {
+            source: './src/index.js',
+            require: './dist/index.js',
+          },
+        },
+      },
+      {
+        'src/index.js': `module.exports = 'configured-source';`,
+        'dist/index.js': `module.exports = 'configured-dist';`,
+      },
+    );
+    const referencedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/referenced-only',
+      {
+        exports: {
+          '.': {
+            source: './src/index.js',
+            require: './dist/index.js',
+          },
+        },
+      },
+      {
+        'src/index.js': `module.exports = 'referenced-source';`,
+        'dist/index.js': `module.exports = 'referenced-dist';`,
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: { composite: true },
+        }),
+      },
+    );
+    const appTsconfigPath = path.join(appRoot, 'tsconfig.json');
+    fs.writeFileSync(appTsconfigPath, JSON.stringify({ compilerOptions: {} }));
+    linkPackage(appRoot, selectedPackage);
+    linkPackage(appRoot, referencedPackage);
+
+    await expect(
+      compileRequests(
+        appRoot,
+        createPackages(selectedPackage),
+        [selectedPackage.name, referencedPackage.name],
+        {
+          tsConfig: {
+            configFile: appTsconfigPath,
+            references: [path.join(referencedPackage.root, 'tsconfig.json')],
+          },
+        },
+      ),
+    ).resolves.toEqual(['configured-source', 'referenced-dist']);
+  });
+
+  test('does not source-build a node_modules package that only shares a selected package name', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-package-root-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/shared-name',
+      {
+        source: './src/index.js',
+        main: './dist/index.js',
+      },
+      {
+        'src/index.js': `module.exports = 'workspace-source';`,
+        'dist/index.js': `module.exports = 'workspace-dist';`,
+      },
+    );
+    writeFiles(path.join(appRoot, 'node_modules', selectedPackage.name), {
+      'package.json': JSON.stringify({
+        name: selectedPackage.name,
+        source: './src/index.js',
+        main: './dist/index.js',
+      }),
+      'src/index.js': `module.exports = 'node-modules-source';`,
+      'dist/index.js': `module.exports = 'node-modules-dist';`,
+    });
+
+    await expect(
+      compileRequests(appRoot, createPackages(selectedPackage), [
+        selectedPackage.name,
+      ]),
+    ).resolves.toEqual(['node-modules-dist']);
+  });
+
+  test('builds only selected workspace packages from source', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-scoped-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/selected',
+      {
+        source: './src/index.ts',
+        main: './dist/index.js',
+        exports: {
+          '.': {
+            source: './src/index.ts',
+            require: './dist/index.js',
+          },
+          './*.css': {
+            source: './src/*.scss',
+            require: './dist/*.css',
+          },
+        },
+      },
+      {
+        'src/index.ts': `module.exports = 'selected-source';`,
+        'src/theme.scss': `module.exports = 'selected-style';`,
+        'dist/index.js': `module.exports = 'selected-dist';`,
+        'dist/theme.css': `module.exports = 'selected-dist-style';`,
+      },
+    );
+    const externalPackage = createTestPackage(
+      fixtureRoot,
+      '@test/external',
+      {
+        exports: {
+          '.': {
+            source: './src/index.js',
+            require: './dist/index.js',
+          },
+        },
+      },
+      {
+        'src/index.js': `module.exports = 'external-source';`,
+        'dist/index.js': `module.exports = 'external-dist';`,
+      },
+    );
+    linkPackage(appRoot, selectedPackage);
+    linkPackage(appRoot, externalPackage);
+
+    await expect(
+      compileRequests(appRoot, createPackages(selectedPackage), [
+        selectedPackage.name,
+        `${selectedPackage.name}/theme.css?raw`,
+      ]),
+    ).resolves.toEqual(['selected-source', 'selected-style']);
+    await expect(
+      compileRequests(appRoot, createPackages(), [externalPackage.name]),
+    ).resolves.toEqual(['external-dist']);
+  });
+
+  test('keeps explicit aliases ahead of source rewrites and follows alias fallbacks', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-alias-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/source-target',
+      { source: './src/index.js' },
+      { 'src/index.js': `module.exports = 'workspace-source';` },
+    );
+    const mockPath = path.join(appRoot, 'mock.js');
+    fs.writeFileSync(mockPath, `module.exports = 'explicit-alias';`);
+    linkPackage(appRoot, selectedPackage);
+
+    await expect(
+      compileRequests(
+        appRoot,
+        createPackages(selectedPackage),
+        [selectedPackage.name],
+        {
+          alias: { [selectedPackage.name]: mockPath },
+        },
+      ),
+    ).resolves.toEqual(['explicit-alias']);
+
+    await expect(
+      compileRequests(
+        appRoot,
+        createPackages(selectedPackage),
+        [selectedPackage.name],
+        {
+          ruleAlias: { [selectedPackage.name]: mockPath },
+        },
+      ),
+    ).resolves.toEqual(['explicit-alias']);
+
+    await expect(
+      compileRequests(
+        appRoot,
+        createPackages(selectedPackage),
+        [selectedPackage.name],
+        {
+          byDependencyAlias: { [selectedPackage.name]: mockPath },
+        },
+      ),
+    ).resolves.toEqual(['explicit-alias']);
+
+    await expect(
+      compileRequests(
+        appRoot,
+        createPackages(selectedPackage),
+        ['@test/public-entry'],
+        {
+          alias: {
+            '@test/public-entry': [
+              '@test/missing-entry',
+              '@test/intermediate-entry',
+            ],
+            '@test/intermediate-entry': selectedPackage.name,
+          },
+        },
+      ),
+    ).resolves.toEqual(['workspace-source']);
+  });
+
+  test('keeps user externals ahead of scoped source resolution', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-externals-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    fs.mkdirSync(appRoot, { recursive: true });
+
+    const externalizedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/externalized-workspace',
+      {
+        source: './src/index.js',
+        main: './dist/index.js',
+      },
+      {
+        'src/index.js': `module.exports = 'externalized-source';`,
+        'dist/index.js': `module.exports = 'externalized-output';`,
+      },
+    );
+    const sourcePackage = createTestPackage(
+      fixtureRoot,
+      '@test/non-externalized-workspace',
+      {
+        source: './src/index.js',
+        main: './dist/index.js',
+      },
+      {
+        'src/index.js': `module.exports = 'selected-source';`,
+        'dist/index.js': `module.exports = 'selected-output';`,
+      },
+    );
+    linkPackage(appRoot, externalizedPackage);
+    linkPackage(appRoot, sourcePackage);
+
+    await expect(
+      compileRequests(
+        appRoot,
+        createPackages(externalizedPackage, sourcePackage),
+        [externalizedPackage.name, sourcePackage.name],
+        {
+          externals: {
+            [externalizedPackage.name]: `commonjs ${externalizedPackage.name}`,
+          },
+        },
+      ),
+    ).resolves.toEqual(['externalized-output', 'selected-source']);
+  });
+
+  test('rewrites source requests made through loader resolvers', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-loader-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    const outputPath = path.join(appRoot, 'dist');
+    fs.mkdirSync(appRoot, { recursive: true });
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/loader-style',
+      {
+        exports: {
+          './*.css': {
+            source: './src/*.scss',
+            require: './dist/*.css',
+          },
+        },
+      },
+      { 'src/theme.scss': '' },
+    );
+    const loaderPath = path.join(appRoot, 'resolve-loader.cjs');
+    linkPackage(appRoot, selectedPackage);
+    fs.writeFileSync(
+      loaderPath,
+      `module.exports = function () {
+        const callback = this.async();
+        this.getResolve({ extensions: ['.scss'] })(
+          this.context,
+          '@test/loader-public',
+          (error, result) => callback(error, 'module.exports = ' + JSON.stringify(result)),
+        );
+      };`,
+    );
+    fs.writeFileSync(
+      path.join(appRoot, 'entry.js'),
+      `module.exports = require('./style.fixture');`,
+    );
+    fs.writeFileSync(path.join(appRoot, 'style.fixture'), '');
+
+    const compiler = rspack({
+      context: appRoot,
+      entry: './entry.js',
+      mode: 'development',
+      target: 'node',
+      output: {
+        filename: 'bundle.js',
+        library: { type: 'commonjs2' },
+        path: outputPath,
+      },
+      module: {
+        rules: [{ test: /\.fixture$/, use: loaderPath }],
+      },
+      plugins: [
+        new SourceBuildResolverPlugin(
+          createPackages(selectedPackage),
+          'source',
+        ),
+      ],
+      resolve: {
+        alias: {
+          '@test/loader-public': `${selectedPackage.name}/theme.css`,
+        },
+      },
+    });
+
+    await runCompiler(compiler);
+
+    const bundlePath = path.join(outputPath, 'bundle.js');
+    delete loadModule.cache[bundlePath];
+    expect(loadModule(bundlePath)).toBe(
+      path.join(selectedPackage.root, 'src/theme.scss'),
+    );
+  });
+
+  test('applies scoped resolution and child-specific aliases in child compilers', async () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'source-build-child-'),
+    );
+    temporaryDirectories.push(fixtureRoot);
+    const appRoot = path.join(fixtureRoot, 'app');
+    const outputPath = path.join(appRoot, 'dist');
+    fs.mkdirSync(appRoot, { recursive: true });
+    const mockedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/child-mocked',
+      { source: './src/index.js' },
+      { 'src/index.js': `module.exports = 'unexpected-source';` },
+    );
+    const selectedPackage = createTestPackage(
+      fixtureRoot,
+      '@test/child-source',
+      { source: './src/index.js' },
+      { 'src/index.js': `module.exports = 'child-workspace-source';` },
+    );
+    const mockPath = path.join(appRoot, 'child-mock.js');
+    linkPackage(appRoot, selectedPackage);
+    fs.writeFileSync(mockPath, `module.exports = 'child-explicit-alias';`);
+    fs.writeFileSync(
+      path.join(appRoot, 'entry.js'),
+      `module.exports = 'parent';`,
+    );
+    fs.writeFileSync(
+      path.join(appRoot, 'child-entry.js'),
+      `module.exports = [require('${mockedPackage.name}'), require('${selectedPackage.name}')];`,
+    );
+
+    const compiler = rspack({
+      context: appRoot,
+      entry: './entry.js',
+      mode: 'development',
+      target: 'node',
+      output: { filename: 'bundle.js', path: outputPath },
+      plugins: [
+        new SourceBuildResolverPlugin(
+          createPackages(mockedPackage, selectedPackage),
+          'source',
+        ),
+        createChildCompilerPlugin(mockedPackage.name, mockPath),
+      ],
+      resolve: { extensions: ['.js'] },
+    });
+
+    await runCompiler(compiler);
+
+    const childBundle = fs.readFileSync(
+      path.join(outputPath, 'child.js'),
+      'utf8',
+    );
+    expect(childBundle).toContain('child-explicit-alias');
+    expect(childBundle).toContain('child-workspace-source');
+    expect(childBundle).not.toContain('unexpected-source');
+  });
+});

--- a/test/source-build-versions.test.ts
+++ b/test/source-build-versions.test.ts
@@ -1,0 +1,124 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRsbuild as createRsbuildV2 } from '@rsbuild/core';
+import { createRsbuild as createRsbuildV1 } from '@rsbuild/core-1.0';
+import { afterEach, expect, test } from '@rstest/core';
+import { pluginSourceBuild } from '../src/index.js';
+
+const loadModule = createRequire(import.meta.url);
+const fixtureRoot = fileURLToPath(
+  new URL('../fixtures/source-build-monorepo', import.meta.url),
+);
+const temporaryDirectories: string[] = [];
+const rsbuildV1Version = (
+  loadModule('@rsbuild/core-1.0/package.json') as { version: string }
+).version;
+const rsbuildV2Version = (
+  loadModule('@rsbuild/core/package.json') as { version: string }
+).version;
+
+const rsbuildVersions = [
+  {
+    name: `Rsbuild ${rsbuildV1Version}`,
+    createRsbuild: createRsbuildV1,
+  },
+  {
+    name: `Rsbuild ${rsbuildV2Version}`,
+    createRsbuild: createRsbuildV2,
+  },
+];
+
+function linkPackage(
+  monorepoRoot: string,
+  packageName: string,
+  packageRoot: string,
+): void {
+  const packageLink = path.join(monorepoRoot, 'node_modules', packageName);
+  fs.mkdirSync(path.dirname(packageLink), { recursive: true });
+  fs.symlinkSync(
+    packageRoot,
+    packageLink,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+}
+
+function prepareFixture(): string {
+  const temporaryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'source-build-version-matrix-'),
+  );
+  temporaryDirectories.push(temporaryRoot);
+
+  const monorepoRoot = path.join(temporaryRoot, 'monorepo');
+  fs.cpSync(fixtureRoot, monorepoRoot, { recursive: true });
+
+  for (const packageDirectory of [
+    'source-first',
+    'output-first',
+    'transitive',
+    'undeclared',
+  ]) {
+    linkPackage(
+      monorepoRoot,
+      `@fixture/${packageDirectory}`,
+      path.join(monorepoRoot, 'packages', packageDirectory),
+    );
+  }
+
+  fs.cpSync(
+    path.join(monorepoRoot, 'vendor', 'external'),
+    path.join(monorepoRoot, 'node_modules/@fixture/external'),
+    { recursive: true },
+  );
+
+  return path.join(monorepoRoot, 'app');
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+for (const { createRsbuild, name } of rsbuildVersions) {
+  test(`${name} builds the fixture through scoped workspace source resolution`, async () => {
+    const appRoot = prepareFixture();
+    const rsbuild = await createRsbuild({
+      cwd: appRoot,
+      rsbuildConfig: {
+        mode: 'development',
+        source: { entry: { index: './src/index.ts' } },
+        output: {
+          target: 'node',
+          distPath: { root: 'dist' },
+          filename: { js: '[name].js' },
+        },
+        plugins: [
+          pluginSourceBuild({
+            resolvePriority: {
+              '@fixture/output-first': 'output',
+            },
+          }),
+        ],
+        tools: {
+          rspack: {
+            output: { library: { type: 'commonjs2' } },
+          },
+        },
+      },
+    } as never);
+
+    await rsbuild.build();
+
+    const bundlePath = path.join(appRoot, 'dist/index.js');
+    delete loadModule.cache[bundlePath];
+    expect(loadModule(bundlePath).default).toEqual([
+      'source-first:transitive-source',
+      'output-first-dist',
+      'undeclared-dist',
+      'external-dist',
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary

- scope Rspack source resolution to dependent workspace projects discovered by the active monorepo strategy
- support global and per-package `resolvePriority` without adding a separate package-selection API
- preserve native aliases, dependency conditions, user externals, loader resolvers, child compilers, and source/output fallback behavior
- rely on Rspack's module graph and watch dependencies instead of manually extending `source.include`
- expose the existing monorepo adapter types needed by framework integrations

## Compatibility

- use dependency-specific `getResolve` when available
- retain a documented resolver-factory fallback for Rsbuild/Rspack 1.x, including watch dependency propagation
- add a real-version matrix covering Rsbuild 1.0.1 and 2.1.13

## Tests

- add focused resolver, adapter, Rspack lifecycle, externals, alias, child-compiler, and watch tests
- add a miniature monorepo fixture covering direct and transitive source dependencies, package-level output priority, undeclared workspace packages, and external `node_modules` packages

```bash
pnpm install --frozen-lockfile
pnpm exec playwright install chromium
pnpm exec rstest run
pnpm lint
pnpm build
```

Local verification: 24/24 tests passed; Rslint reported 0 errors and 0 warnings; build, formatting, frozen lockfile, and diff checks passed.

## Documentation

- document the scoped resolution model and public options in English and Chinese
- add contribution guidelines and a pull request template
